### PR TITLE
Update subsetting and helper refactoring

### DIFF
--- a/.kiro/specs/config-validation/.config.kiro
+++ b/.kiro/specs/config-validation/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "e93a433f-f45a-4011-be74-3f9c65efae55", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/config-validation/design.md
+++ b/.kiro/specs/config-validation/design.md
@@ -1,0 +1,267 @@
+# Design Document: Config Validation
+
+## Overview
+
+This feature introduces a `ConfigValidator` class in a new module `Bandit/config_validator.py` that performs comprehensive, early validation of the Bandit YAML configuration before any heavy processing begins. The validator is invoked in the `extract` function immediately after the `Cfg` object is constructed and before any `ParamDb`, `ControlFile`, `Cbh`, or network operations.
+
+The validator collects all errors across all checks and reports them in a single pass, so the modeler can fix every issue at once rather than iterating through one failure at a time.
+
+### Design Decisions
+
+1. **Separate module**: The validator lives in its own module (`Bandit/config_validator.py`) rather than being embedded in `bandit_cfg.py` or `bandit.py`. This keeps validation logic decoupled from both the config-loading mechanism and the extraction workflow, making it independently testable.
+
+2. **Operates on the `Cfg` instance**: The validator accepts a `Cfg` object and calls its existing `get_value` / `exists` / `is_empty` methods. This avoids duplicating config-access logic and respects the existing default-value fallback behavior in `Cfg`.
+
+3. **Error accumulation pattern**: Rather than raising on the first failure, the validator accumulates a list of error strings and returns them. The caller (`extract`) decides how to log and exit. This keeps the validator a pure function of config state → error list, which is easy to test.
+
+4. **No changes to `Cfg` class**: The existing `Cfg` class is not modified. The validator is a consumer of `Cfg`, not an extension of it.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[extract function] -->|constructs| B[Cfg object]
+    A -->|passes Cfg to| C[ConfigValidator]
+    C -->|calls get_value/exists/is_empty| B
+    C -->|returns| D[List of error strings]
+    A -->|if errors| E[Log errors + exit]
+    A -->|if no errors| F[Continue extraction]
+```
+
+The validation flow within `ConfigValidator.validate()` follows a fixed order:
+
+```mermaid
+flowchart TD
+    V1[1. Core field presence] --> V2[2. Date format & range]
+    V2 --> V3[3. Path existence on disk]
+    V3 --> V4[4. Conditional CBH fields]
+    V4 --> V5[5. Conditional model output fields]
+    V5 --> V6[6. Conditional streamflow fields]
+    V6 --> V7[7. Conditional GIS fields]
+    V7 --> V8[8. List element types]
+    V8 --> VR[Return all collected errors]
+```
+
+All steps run regardless of earlier failures — errors are accumulated, not short-circuited. The one exception is that path-existence checks (step 3) skip fields that were already flagged as missing/empty in step 1, since checking a path for an empty string is meaningless.
+
+## Components and Interfaces
+
+### `ConfigValidator` class
+
+**Module**: `Bandit/config_validator.py`
+
+```python
+class ConfigValidator:
+    """Validates a Bandit Cfg object before extraction begins."""
+
+    def __init__(self, config: Cfg):
+        """
+        :param config: A loaded Cfg instance to validate.
+        """
+
+    def validate(self) -> List[str]:
+        """Run all validation checks and return a list of error messages.
+
+        Returns an empty list if the configuration is valid.
+        """
+
+    # --- Internal validation methods (all append to self._errors) ---
+
+    def _validate_core_fields(self) -> Set[str]:
+        """Check that core required fields are present and non-empty.
+        Returns the set of field names that failed (used to skip
+        downstream path checks on those fields).
+        """
+
+    def _validate_dates(self) -> None:
+        """Check date format (YYYY-MM-DD) and that start_date < end_date."""
+
+    def _validate_paths(self, skip_fields: Set[str]) -> None:
+        """Check that required paths exist on disk.
+        Skips any field in skip_fields (already flagged as missing).
+        Checks cbh_dir only when output_cbh is true.
+        """
+
+    def _validate_cbh_fields(self) -> None:
+        """When output_cbh is true, check cbh_dir and cbh_var_map."""
+
+    def _validate_model_output_fields(self) -> None:
+        """When include_model_output is true, check output_vars_dir and output_vars."""
+
+    def _validate_streamflow_fields(self) -> None:
+        """When output_streamflow is true, check streamflow_filename."""
+
+    def _validate_gis_fields(self) -> None:
+        """When output_shapefiles is true, check gis structure."""
+
+    def _validate_list_types(self) -> None:
+        """Check that outlets, cutoffs, hru_noroute contain only integers."""
+```
+
+### Integration point in `extract`
+
+A small block is added to `Bandit/bandit.py` after `config = bc.Cfg(config_file)` and before any other processing:
+
+```python
+from Bandit.config_validator import ConfigValidator
+
+# ... inside extract(), after config = bc.Cfg(config_file):
+validator = ConfigValidator(config)
+errors = validator.validate()
+if errors:
+    for err in errors:
+        bandit_log.error(err)
+        con.print(f'[red]ERROR[/]: {err}')
+    con.print(f'[red]Configuration has {len(errors)} error(s). Fix the above issues and retry.[/]')
+    exit(2)
+```
+
+### Public interface summary
+
+| Component | Method | Input | Output |
+|---|---|---|---|
+| `ConfigValidator.__init__` | constructor | `Cfg` instance | — |
+| `ConfigValidator.validate` | run all checks | — | `List[str]` (error messages) |
+
+No other public methods are exposed. The internal `_validate_*` methods are implementation details.
+
+## Data Models
+
+The validator does not introduce new data models. It operates on the existing `Cfg` object and the `default_values` dictionary defined in `bandit_cfg.py`.
+
+### Configuration field classification
+
+| Category | Fields | Validation |
+|---|---|---|
+| Core required (always) | `output_dir`, `param_filename`, `paramdb_dir`, `control_filename`, `start_date`, `end_date` | Present and non-empty |
+| Date fields | `start_date`, `end_date` | YYYY-MM-DD format, start < end |
+| Path fields (always) | `paramdb_dir` (dir), `control_filename` (file) | Exists on disk |
+| Path fields (conditional) | `cbh_dir` (file or dir) | Exists on disk when `output_cbh` is true |
+| Conditional: CBH | `cbh_dir`, `cbh_var_map` | Non-empty when `output_cbh` is true |
+| Conditional: Model output | `output_vars_dir`, `output_vars` | Non-empty when `include_model_output` is true |
+| Conditional: Streamflow | `streamflow_filename` | Non-empty when `output_streamflow` is true |
+| Conditional: GIS | `gis`, `gis[src_filename]`, `gis[dst_extension]`, `gis[layers]` | Non-empty dict with required keys when `output_shapefiles` is true |
+| List type checks | `outlets`, `cutoffs`, `hru_noroute` | All elements are integers |
+
+### Error message format
+
+Each error message is a plain string following one of these patterns:
+
+- `"Required field '{name}' is missing or empty"`
+- `"Field '{name}' has invalid date format '{value}'; expected YYYY-MM-DD"`
+- `"'start_date' ({start}) must precede 'end_date' ({end})"`
+- `"Path for '{name}' does not exist: {path}"`
+- `"Field '{name}' is required when '{toggle}' is enabled"`
+- `"Field '{name}' must be a non-empty dictionary when '{toggle}' is enabled"`
+- `"GIS config is missing required key '{key}'"`
+- `"Field '{name}' contains non-integer element: {element}"`
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Core field presence detection
+
+*For any* configuration dictionary and *for any* subset of the core fields (`output_dir`, `param_filename`, `paramdb_dir`, `control_filename`, `start_date`, `end_date`) that are missing or empty, the validator SHALL return an error for each such field, and the error message SHALL contain the field name.
+
+**Validates: Requirements 1.1, 1.2, 1.3**
+
+### Property 2: Date format validation
+
+*For any* string value assigned to `start_date` or `end_date`, the validator SHALL produce a date-format error if and only if the string is not parseable as a valid `YYYY-MM-DD` date. The error message SHALL contain the field name and the invalid value.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 3: Date ordering
+
+*For any* two valid `YYYY-MM-DD` date strings assigned to `start_date` and `end_date`, the validator SHALL produce a date-ordering error if and only if `start_date >= end_date`. The error message SHALL contain both date values.
+
+**Validates: Requirements 3.4**
+
+### Property 4: Conditional field validation
+
+*For any* conditional toggle (`output_cbh`, `include_model_output`, `output_streamflow`) and its associated required fields (`cbh_dir`/`cbh_var_map`, `output_vars_dir`/`output_vars`, `streamflow_filename`), the validator SHALL produce an error for a field if and only if the toggle is `true` and the field is missing or empty. When the toggle is `false`, no error SHALL be produced regardless of the field's value.
+
+**Validates: Requirements 4.1, 4.2, 4.3, 4.4, 5.1, 5.2, 5.3, 5.4, 6.1, 6.2**
+
+### Property 5: GIS structure validation
+
+*For any* configuration where `output_shapefiles` is `true`, the validator SHALL produce an error if `gis` is not a non-empty dictionary, or if `gis` is missing any of the keys `src_filename`, `dst_extension`, or `layers`, or if `gis['src_filename']` is empty, or if `gis['layers']` is not a non-empty dictionary. When `output_shapefiles` is `false`, no GIS-related errors SHALL be produced.
+
+**Validates: Requirements 7.1, 7.2, 7.3, 7.4, 7.5**
+
+### Property 6: List element type validation
+
+*For any* of the list fields (`outlets`, `cutoffs`, `hru_noroute`) that contain at least one element, the validator SHALL produce an error for each non-integer element. The error message SHALL name the field and identify the invalid element. If all elements are integers, no error SHALL be produced for that field.
+
+**Validates: Requirements 8.1, 8.2, 8.3, 8.4**
+
+### Property 7: Path existence validation
+
+*For any* configuration where `paramdb_dir` is non-empty, the validator SHALL produce an error if the path does not exist as a directory on disk. *For any* configuration where `control_filename` is non-empty, the validator SHALL produce an error if the path does not exist as a file on disk. *For any* configuration where `output_cbh` is `true` and `cbh_dir` is non-empty, the validator SHALL produce an error if the path does not exist on disk. When a path field was already flagged as missing/empty, no path-existence error SHALL be produced for it.
+
+**Validates: Requirements 2.1, 2.2, 2.3, 2.4**
+
+## Error Handling
+
+### Validation errors
+
+The `ConfigValidator.validate()` method never raises exceptions. It returns a `List[str]` of error messages. The caller (`extract`) is responsible for:
+
+1. Logging each error at the ERROR level via `bandit_log.error()`
+2. Printing each error to the console via `con.print()` with red formatting
+3. Printing a summary count of errors
+4. Calling `exit(2)` to terminate with a non-zero status code
+
+### Unexpected exceptions during validation
+
+If an unexpected exception occurs during validation (e.g., a `Cfg` method raises), the validator lets it propagate. This is intentional — the `Cfg` class already handles its own error cases (e.g., `KeyError` for unknown config variables), and wrapping those would obscure the root cause.
+
+### Edge cases
+
+- **Empty config file**: All core fields will fall back to `default_values` in `Cfg`. Fields like `output_dir` and `paramdb_dir` default to `''`, so they will be caught by the core-field presence check.
+- **Boolean toggles default to `False`**: Conditional checks are skipped when toggles are `False`, so an empty config won't trigger conditional-field errors.
+- **YAML type coercion**: `ruamel.yaml` may parse bare values like `2024-01-01` as `datetime.date` objects rather than strings. The date validator should handle both string and `datetime.date` inputs gracefully.
+
+## Testing Strategy
+
+### Test framework
+
+- **Unit tests**: `pytest` (already in dev dependencies)
+- **Property-based tests**: `hypothesis` (to be added to dev dependencies)
+
+### Property-based tests
+
+Each correctness property maps to a single Hypothesis test. All property tests run a minimum of 100 iterations.
+
+| Property | Test | Strategy |
+|---|---|---|
+| 1: Core field presence | `test_core_field_presence` | Generate random subsets of core fields to omit/empty. Verify each missing field appears in errors. |
+| 2: Date format | `test_date_format_validation` | Generate random strings (valid YYYY-MM-DD, invalid formats, edge dates). Verify error iff not parseable. |
+| 3: Date ordering | `test_date_ordering` | Generate random pairs of valid dates. Verify error iff start >= end. |
+| 4: Conditional fields | `test_conditional_field_validation` | Generate random toggle states and field values. Verify error iff toggle=true and field empty. |
+| 5: GIS structure | `test_gis_structure_validation` | Generate random gis dicts with subsets of required keys. Verify errors match missing/empty keys. |
+| 6: List element types | `test_list_element_types` | Generate lists with random mixes of ints and non-ints. Verify error for each non-int element. |
+| 7: Path existence | `test_path_existence_validation` | Use `tmp_path` fixture to create/omit paths. Verify error iff path doesn't exist. |
+
+Tag format for each test: `# Feature: config-validation, Property {N}: {title}`
+
+### Unit tests (example-based)
+
+- **Integration smoke test**: Verify that `extract()` calls the validator before `ParamDb` (validates Req 9.1, 9.2)
+- **Logging integration**: Verify errors are logged at ERROR level and printed to console (validates Req 10.2, 10.3, 10.4)
+- **YAML type coercion edge case**: Verify that `datetime.date` objects from YAML are handled correctly in date validation
+- **Valid config produces no errors**: A fully valid config returns an empty error list
+
+### Test file location
+
+`tests/test_config_validator.py`
+
+### Configuration for Hypothesis
+
+```python
+from hypothesis import settings
+
+@settings(max_examples=100)
+```

--- a/.kiro/specs/config-validation/requirements.md
+++ b/.kiro/specs/config-validation/requirements.md
@@ -1,0 +1,122 @@
+# Requirements Document
+
+## Introduction
+
+The `extract` function in `Bandit/bandit.py` reads numerous configuration attributes (e.g., `config.output_dir`, `config.paramdb_dir`, `config.gis['src_filename']`) without any upfront validation. When the configuration is malformed or missing required fields, errors surface deep in the extraction process with cryptic messages that are difficult to diagnose. This feature adds early validation of required configuration fields at the start of the `extract` function, providing clear, actionable error messages before any heavy processing begins.
+
+## Glossary
+
+- **Config_Validator**: The validation component that checks configuration fields for presence, correct types, and structural completeness before extraction begins.
+- **Cfg**: The existing configuration class (`Bandit.bandit_cfg.Cfg`) that loads YAML configuration files and provides attribute-style access to configuration values.
+- **Extract_Function**: The main `extract` function in `Bandit/bandit.py` that performs NHM model subset extraction.
+- **Required_Field**: A configuration field that must be present and non-empty for the extraction to proceed.
+- **Conditional_Field**: A configuration field that is required only when a related boolean toggle is enabled (e.g., `cbh_var_map` is required only when `output_cbh` is true).
+- **GIS_Config**: The nested dictionary configuration under the `gis` key, containing `src_filename`, `dst_extension`, and `layers` sub-keys.
+
+## Requirements
+
+### Requirement 1: Validate Required Core Fields
+
+**User Story:** As a modeler, I want the extraction process to validate that all required core configuration fields are present and non-empty before processing begins, so that I receive clear error messages instead of cryptic failures deep in the workflow.
+
+#### Acceptance Criteria
+
+1. WHEN the `extract` function is called, THE Config_Validator SHALL check that each of the following fields is present and non-empty in the loaded configuration: `output_dir`, `param_filename`, `paramdb_dir`, `control_filename`, `start_date`, `end_date`.
+2. IF a required core field is missing or empty, THEN THE Config_Validator SHALL raise an error that names the missing field and states that it is required.
+3. IF multiple required core fields are missing or empty, THEN THE Config_Validator SHALL report all missing fields in a single error message rather than failing on the first missing field.
+
+### Requirement 2: Validate Required Path Fields Exist on Disk
+
+**User Story:** As a modeler, I want the validator to check that required directory and file paths actually exist on disk, so that I learn about missing paths before the extraction attempts to read from them.
+
+#### Acceptance Criteria
+
+1. WHEN the configuration passes field-presence validation, THE Config_Validator SHALL verify that the path specified by `paramdb_dir` exists as a directory on disk.
+2. WHEN the configuration passes field-presence validation, THE Config_Validator SHALL verify that the path specified by `control_filename` exists as a file on disk.
+3. WHILE `output_cbh` is true, THE Config_Validator SHALL verify that the path specified by `cbh_dir` exists on disk as a file or directory.
+4. IF a required path does not exist on disk, THEN THE Config_Validator SHALL raise an error that names the field and includes the non-existent path value.
+
+### Requirement 3: Validate Date Fields
+
+**User Story:** As a modeler, I want the validator to check that date fields contain parseable date strings and that the start date precedes the end date, so that I avoid confusing date-related errors during processing.
+
+#### Acceptance Criteria
+
+1. WHEN the configuration passes field-presence validation, THE Config_Validator SHALL verify that `start_date` is a string parseable as a date in `YYYY-MM-DD` format.
+2. WHEN the configuration passes field-presence validation, THE Config_Validator SHALL verify that `end_date` is a string parseable as a date in `YYYY-MM-DD` format.
+3. IF `start_date` or `end_date` is not parseable as a `YYYY-MM-DD` date, THEN THE Config_Validator SHALL raise an error that names the field and includes the invalid value.
+4. IF `start_date` is equal to or later than `end_date`, THEN THE Config_Validator SHALL raise an error stating that `start_date` must precede `end_date` and include both date values.
+
+### Requirement 4: Validate Conditional CBH Fields
+
+**User Story:** As a modeler, I want the validator to check CBH-related fields when CBH output is enabled, so that missing CBH configuration is caught before the extraction reaches the CBH processing stage.
+
+#### Acceptance Criteria
+
+1. WHILE `output_cbh` is true, THE Config_Validator SHALL verify that `cbh_dir` is present and non-empty.
+2. WHILE `output_cbh` is true, THE Config_Validator SHALL verify that `cbh_var_map` is a non-empty dictionary.
+3. IF `output_cbh` is true and `cbh_dir` is missing or empty, THEN THE Config_Validator SHALL raise an error stating that `cbh_dir` is required when `output_cbh` is enabled.
+4. IF `output_cbh` is true and `cbh_var_map` is missing or empty, THEN THE Config_Validator SHALL raise an error stating that `cbh_var_map` is required when `output_cbh` is enabled.
+
+### Requirement 5: Validate Conditional Model Output Fields
+
+**User Story:** As a modeler, I want the validator to check model-output-related fields when model output is enabled, so that missing output configuration is caught early.
+
+#### Acceptance Criteria
+
+1. WHILE `include_model_output` is true, THE Config_Validator SHALL verify that `output_vars_dir` is a non-empty string.
+2. WHILE `include_model_output` is true, THE Config_Validator SHALL verify that `output_vars` is a non-empty list.
+3. IF `include_model_output` is true and `output_vars_dir` is missing or empty, THEN THE Config_Validator SHALL raise an error stating that `output_vars_dir` is required when `include_model_output` is enabled.
+4. IF `include_model_output` is true and `output_vars` is missing or empty, THEN THE Config_Validator SHALL raise an error stating that `output_vars` is required when `include_model_output` is enabled.
+
+### Requirement 6: Validate Conditional Streamflow Fields
+
+**User Story:** As a modeler, I want the validator to check streamflow-related fields when streamflow output is enabled, so that missing streamflow configuration is caught early.
+
+#### Acceptance Criteria
+
+1. WHILE `output_streamflow` is true, THE Config_Validator SHALL verify that `streamflow_filename` is a non-empty string.
+2. IF `output_streamflow` is true and `streamflow_filename` is missing or empty, THEN THE Config_Validator SHALL raise an error stating that `streamflow_filename` is required when `output_streamflow` is enabled.
+
+### Requirement 7: Validate Conditional GIS Fields
+
+**User Story:** As a modeler, I want the validator to check GIS-related fields when shapefile output is enabled, so that missing or malformed GIS configuration is caught before the shapefile writing stage.
+
+#### Acceptance Criteria
+
+1. WHILE `output_shapefiles` is true, THE Config_Validator SHALL verify that `gis` is a non-empty dictionary.
+2. WHILE `output_shapefiles` is true, THE Config_Validator SHALL verify that `gis` contains the keys `src_filename`, `dst_extension`, and `layers`.
+3. WHILE `output_shapefiles` is true, THE Config_Validator SHALL verify that `gis['src_filename']` is a non-empty string.
+4. WHILE `output_shapefiles` is true, THE Config_Validator SHALL verify that `gis['layers']` is a non-empty dictionary.
+5. IF `output_shapefiles` is true and any required GIS sub-key is missing or empty, THEN THE Config_Validator SHALL raise an error that names the missing sub-key within the `gis` configuration.
+
+### Requirement 8: Validate List Fields Have Correct Element Types
+
+**User Story:** As a modeler, I want the validator to check that list-typed configuration fields contain elements of the expected type, so that type errors do not surface as cryptic failures during array operations.
+
+#### Acceptance Criteria
+
+1. WHEN `outlets` is non-empty, THE Config_Validator SHALL verify that each element in `outlets` is an integer.
+2. WHEN `cutoffs` is non-empty, THE Config_Validator SHALL verify that each element in `cutoffs` is an integer.
+3. WHEN `hru_noroute` is non-empty, THE Config_Validator SHALL verify that each element in `hru_noroute` is an integer.
+4. IF a list field contains an element of an unexpected type, THEN THE Config_Validator SHALL raise an error that names the field and identifies the invalid element.
+
+### Requirement 9: Run Validation Before Heavy Processing
+
+**User Story:** As a modeler, I want all configuration validation to complete before any parameter database loading, network construction, or file I/O begins, so that I get fast feedback on configuration problems.
+
+#### Acceptance Criteria
+
+1. WHEN the `extract` function is called, THE Config_Validator SHALL execute all validation checks after the `Cfg` object is constructed and before any call to `ParamDb`, `ControlFile`, `Cbh`, network operations, or file writes.
+2. IF any validation check fails, THEN THE Config_Validator SHALL prevent the extraction from proceeding and exit with a non-zero status code.
+
+### Requirement 10: Aggregate Validation Errors
+
+**User Story:** As a modeler, I want to see all configuration errors at once rather than fixing them one at a time, so that I can resolve all issues in a single pass.
+
+#### Acceptance Criteria
+
+1. THE Config_Validator SHALL collect all validation errors across all checks (Requirements 1 through 8) before reporting them.
+2. WHEN one or more validation errors exist, THE Config_Validator SHALL log each error message to the bandit log at the ERROR level.
+3. WHEN one or more validation errors exist, THE Config_Validator SHALL print a summary to the console listing all errors.
+4. WHEN one or more validation errors exist, THE Config_Validator SHALL exit with a non-zero status code after reporting all errors.

--- a/.kiro/specs/config-validation/tasks.md
+++ b/.kiro/specs/config-validation/tasks.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Config Validation
+
+## Overview
+
+Implement a `ConfigValidator` class in `Bandit/config_validator.py` that validates the Bandit YAML configuration before heavy processing begins. The validator accumulates all errors and returns them as a list of strings. Integration into `Bandit/bandit.py` is a thin block after `config = bc.Cfg(config_file)` that logs errors and exits if any are found. Property-based tests with Hypothesis verify each correctness property.
+
+## Tasks
+
+- [x] 1. Create `ConfigValidator` class with core field validation
+  - [x] 1.1 Create `Bandit/config_validator.py` with `ConfigValidator` class skeleton
+    - Define `__init__(self, config: Cfg)` storing the config and an empty `_errors: List[str]`
+    - Define `validate(self) -> List[str]` that calls all `_validate_*` methods in order and returns `_errors`
+    - Define `_validate_core_fields(self) -> Set[str]` that checks `output_dir`, `param_filename`, `paramdb_dir`, `control_filename`, `start_date`, `end_date` are present and non-empty
+    - Return the set of field names that failed so downstream path checks can skip them
+    - Error format: `"Required field '{name}' is missing or empty"`
+    - _Requirements: 1.1, 1.2, 1.3, 10.1_
+
+  - [x] 1.2 Implement `_validate_dates` method
+    - Check that `start_date` and `end_date` are parseable as `YYYY-MM-DD` dates
+    - Handle both `str` and `datetime.date` inputs (YAML type coercion)
+    - Check that `start_date < end_date`; produce error if `start_date >= end_date`
+    - Error formats: `"Field '{name}' has invalid date format '{value}'; expected YYYY-MM-DD"` and `"'start_date' ({start}) must precede 'end_date' ({end})"`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+  - [x] 1.3 Implement `_validate_paths` method
+    - Accept `skip_fields: Set[str]` parameter to skip fields already flagged as missing
+    - Check `paramdb_dir` exists as a directory on disk
+    - Check `control_filename` exists as a file on disk
+    - When `output_cbh` is true and `cbh_dir` not in skip_fields, check `cbh_dir` exists on disk
+    - Error format: `"Path for '{name}' does not exist: {path}"`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [x] 2. Implement conditional field validation methods
+  - [x] 2.1 Implement `_validate_cbh_fields` method
+    - When `output_cbh` is true, check `cbh_dir` is present and non-empty
+    - When `output_cbh` is true, check `cbh_var_map` is a non-empty dictionary
+    - Error format: `"Field '{name}' is required when 'output_cbh' is enabled"` / `"Field '{name}' must be a non-empty dictionary when 'output_cbh' is enabled"`
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [x] 2.2 Implement `_validate_model_output_fields` method
+    - When `include_model_output` is true, check `output_vars_dir` is a non-empty string
+    - When `include_model_output` is true, check `output_vars` is a non-empty list
+    - Error format: `"Field '{name}' is required when 'include_model_output' is enabled"`
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [x] 2.3 Implement `_validate_streamflow_fields` method
+    - When `output_streamflow` is true, check `streamflow_filename` is a non-empty string
+    - Error format: `"Field '{name}' is required when 'output_streamflow' is enabled"`
+    - _Requirements: 6.1, 6.2_
+
+  - [x] 2.4 Implement `_validate_gis_fields` method
+    - When `output_shapefiles` is true, check `gis` is a non-empty dictionary
+    - Check `gis` contains keys `src_filename`, `dst_extension`, `layers`
+    - Check `gis['src_filename']` is a non-empty string
+    - Check `gis['layers']` is a non-empty dictionary
+    - Error format: `"GIS config is missing required key '{key}'"` and related messages
+    - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
+
+  - [x] 2.5 Implement `_validate_list_types` method
+    - Check `outlets`, `cutoffs`, `hru_noroute` contain only integers when non-empty
+    - Error format: `"Field '{name}' contains non-integer element: {element}"`
+    - _Requirements: 8.1, 8.2, 8.3, 8.4_
+
+- [x] 3. Integrate validator into `extract` function
+  - [x] 3.1 Add validation call in `Bandit/bandit.py`
+    - Add `from Bandit.config_validator import ConfigValidator` import
+    - After `config = bc.Cfg(config_file)` and before any `ParamDb`/`ControlFile`/network operations, add validation block
+    - Log each error at ERROR level via `bandit_log.error()`
+    - Print each error to console via `con.print()` with red formatting
+    - Print summary count and call `exit(2)` if errors exist
+    - _Requirements: 9.1, 9.2, 10.2, 10.3, 10.4_
+
+- [x] 4. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Property-based tests for `ConfigValidator`
+  - [ ]* 5.1 Write property test for core field presence detection
+    - **Property 1: Core field presence detection**
+    - Generate random subsets of core fields to omit or set empty; verify each missing field produces an error containing the field name
+    - Use `@settings(max_examples=100)`
+    - **Validates: Requirements 1.1, 1.2, 1.3**
+
+  - [ ]* 5.2 Write property test for date format validation
+    - **Property 2: Date format validation**
+    - Generate random strings (valid YYYY-MM-DD, invalid formats, edge dates, `datetime.date` objects); verify error iff not parseable as YYYY-MM-DD
+    - Use `@settings(max_examples=100)`
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+
+  - [ ]* 5.3 Write property test for date ordering
+    - **Property 3: Date ordering**
+    - Generate random pairs of valid dates; verify error iff `start_date >= end_date`
+    - Use `@settings(max_examples=100)`
+    - **Validates: Requirements 3.4**
+
+  - [ ]* 5.4 Write property test for conditional field validation
+    - **Property 4: Conditional field validation**
+    - Generate random toggle states (`output_cbh`, `include_model_output`, `output_streamflow`) and field values; verify error iff toggle is true and field is missing/empty
+    - Use `@settings(max_examples=100)`
+    - **Validates: Requirements 4.1, 4.2, 4.3, 4.4, 5.1, 5.2, 5.3, 5.4, 6.1, 6.2**
+
+  - [ ]* 5.5 Write property test for GIS structure validation
+    - **Property 5: GIS structure validation**
+    - Generate random `gis` dicts with subsets of required keys; verify errors match missing/empty keys when `output_shapefiles` is true
+    - Use `@settings(max_examples=100)`
+    - **Validates: Requirements 7.1, 7.2, 7.3, 7.4, 7.5**
+
+  - [ ]* 5.6 Write property test for list element type validation
+    - **Property 6: List element type validation**
+    - Generate lists with random mixes of ints and non-ints for `outlets`, `cutoffs`, `hru_noroute`; verify error for each non-integer element
+    - Use `@settings(max_examples=100)`
+    - **Validates: Requirements 8.1, 8.2, 8.3, 8.4**
+
+  - [ ]* 5.7 Write property test for path existence validation
+    - **Property 7: Path existence validation**
+    - Use `tmp_path` fixture to create/omit paths; verify error iff path doesn't exist on disk and field was not already flagged as missing
+    - Use `@settings(max_examples=100)`
+    - **Validates: Requirements 2.1, 2.2, 2.3, 2.4**
+
+- [x] 6. Unit tests for integration and edge cases
+  - [ ]* 6.1 Write unit tests in `tests/test_config_validator.py`
+    - Test that a fully valid config returns an empty error list
+    - Test YAML type coercion edge case (`datetime.date` objects handled correctly)
+    - Test that multiple errors across different categories are all collected in a single pass
+    - Test error count matches expected number of failures
+    - _Requirements: 10.1, 3.1, 3.2_
+
+- [x] 7. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The design uses Python, so all code examples and implementations use Python
+- Hypothesis property tests use `@settings(max_examples=100)` as specified in the design
+- All tests go in `tests/test_config_validator.py`

--- a/Bandit/bandit.py
+++ b/Bandit/bandit.py
@@ -24,6 +24,7 @@ from Bandit import __version__
 from Bandit.bandit_helpers import (create_parameter_subset, parse_gages, set_date, subset_stream_network,
                                    get_hru_and_seg_subset_maps, get_output_order, get_poi_subset)
 from Bandit.git_version import git_commit, git_repo, git_branch, git_commit_url
+from Bandit.config_validator import ConfigValidator
 from Bandit.model_output import ModelOutput
 from Bandit.points_of_interest import POI   # type: ignore
 import Bandit.bandit_cfg as bc   # type: ignore
@@ -128,13 +129,22 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
 
     config = bc.Cfg(config_file)
 
+    validator = ConfigValidator(config)
+    errors = validator.validate()
+    if errors:
+        for err in errors:
+            bandit_log.error(err)
+            con.print(f'[red]ERROR[/]: {err}')
+        con.print(f'[red]Configuration has {len(errors)} error(s). Fix the above issues and retry.[/]')
+        exit(2)
+
     outdir = Path(config.output_dir)   # Where to output the subset
     param_filename = Path(config.param_filename)   # Name of the output parameter file
     paramdb_dir = Path(config.paramdb_dir)   # Location of the NHM parameter database
     cbh_dir = Path(config.cbh_dir)
     dsmost_seg = config.outlets   # List of outlets
     uscutoff_seg = config.cutoffs   # List of upstream cutoffs
-    hru_noroute = np.array(config.hru_noroute)   # List of additional HRUs (have no route to segment within subset)
+    hru_noroute = np.array(config.hru_noroute)   # Array of additional HRUs (have no route to segment within subset)
 
     # if prms_version == 6:
     #     cbh_netcdf = True
@@ -195,15 +205,6 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
 
     if not pdb.exists('poi_gage_segment'):
         con.print('[gold3]WARNING[/]: Missing POI-related parameters. To include POIs, set csvON_OFF > 0 in the control file')
-
-    # Default the various *ON_OFF variables to 0 (off)
-    # The original values are needed to reduce parameters by module,
-    # but it's best to disable them in the final control file since
-    # no output variables are defined for them.
-    disable_vars = ['basinOutON_OFF', 'csvON_OFF', 'mapOutON_OFF', 'nhruOutON_OFF',
-                    'nsegmentOutON_OFF', 'nsubOutON_OFF']
-    for vv in disable_vars:
-        ctl.get(vv).values = 0
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Get tosegment_nhm
@@ -274,8 +275,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     # HRU-related parameters can either be output with the legacy, segment-oriented order
     # or can be output maintaining their original HRU-relative order from the parameter database.
     hru_order_subset, new_hru_segment = get_output_order(hru_to_seg, seg_to_hru, hru_segment,
-                                                         nhm_id_to_idx, new_nhm_seg,
-                                                         new_nhm_seg_to_idx1, hru_noroute,
+                                                         nhm_id_to_idx, new_nhm_seg_to_idx1, hru_noroute,
                                                          keep_hru_order=keep_hru_order)
 
     con.print(f'[green4]INFO[/]: Number of HRUs in model subset: {len(hru_order_subset)}')
@@ -292,13 +292,13 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     # @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Subset poi_gage_segment
-    new_poi_gage_segment, new_poi_gage_id, new_poi_type = get_poi_subset(pdb, new_nhm_seg,
-                                                                         new_nhm_seg_to_idx1,
+    new_poi_gage_segment, new_poi_gage_id, new_poi_type = get_poi_subset(pdb, new_nhm_seg_to_idx1,
                                                                          seg_to_hru,
                                                                          addl_gages=addl_gages)
 
     con.print(f'[green4]INFO[/]: Number of POI gages in model subset: {len(new_poi_gage_id)}')
 
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Process the parameters and create a parameter file for the subset
     new_ps = create_parameter_subset(prms_meta, pdb, hru_order_subset,
                                      new_hru_segment, new_nhm_seg, new_poi_gage_id,
@@ -342,7 +342,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
         else:
             raise ValueError('Missing CBH files')
 
-        # Add the global NHM IDs
+        # Add the global NHM IDs from source parameter database
         cbh_hdl.set_nhm_id(pdb.get('nhm_id').data)
 
         if cbh_netcdf:
@@ -356,7 +356,6 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
             # Set the control file variables for the CBH files
             for cfv in config.cbh_var_map.values():
                 ctl.get(cfv).values = cbh_outfile.name
-
         else:
             for cvar, cfv in config.cbh_var_map.items():
                 if verbose:
@@ -441,6 +440,15 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Write control file
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Default the various *ON_OFF variables to 0 (off)
+    # The original values are needed to reduce parameters by module,
+    # but it's best to disable them in the final control file since
+    # no output variables are defined for them.
+    disable_vars = ['basinOutON_OFF', 'csvON_OFF', 'mapOutON_OFF', 'nhruOutON_OFF',
+                    'nsegmentOutON_OFF', 'nsubOutON_OFF']
+    for vv in disable_vars:
+        ctl.get(vv).values = 0
+
     ctl.write(str(Path(config.control_filename).with_suffix('.bandit')))
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Bandit/bandit.py
+++ b/Bandit/bandit.py
@@ -16,12 +16,13 @@ import pyogrio as pyg  # type: ignore
 
 from cyclopts import App, Parameter, validators
 from dask.distributed import Client
+from numpy.typing import NDArray
 
 from pyPRMS.base.console import get_console_instance
 
 from Bandit import __version__
-from Bandit.bandit_helpers import (parse_gages, set_date, subset_stream_network, get_hru_and_seg_subset_maps,
-                                   get_output_order, get_poi_subset, resize_dims)
+from Bandit.bandit_helpers import (create_parameter_subset, parse_gages, set_date, subset_stream_network,
+                                   get_hru_and_seg_subset_maps, get_output_order, get_poi_subset)
 from Bandit.git_version import git_commit, git_repo, git_branch, git_commit_url
 from Bandit.model_output import ModelOutput
 from Bandit.points_of_interest import POI   # type: ignore
@@ -133,7 +134,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     cbh_dir = Path(config.cbh_dir)
     dsmost_seg = config.outlets   # List of outlets
     uscutoff_seg = config.cutoffs   # List of upstream cutoffs
-    hru_noroute = config.hru_noroute   # List of additional HRUs (have no route to segment within subset)
+    hru_noroute = np.array(config.hru_noroute)   # List of additional HRUs (have no route to segment within subset)
 
     # if prms_version == 6:
     #     cbh_netcdf = True
@@ -204,12 +205,10 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     for vv in disable_vars:
         ctl.get(vv).values = 0
 
-    nhm_global_dimensions = pdb.dimensions
-
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Get tosegment_nhm
     # Convert to list for fastest access to array
-    nhm_seg = pdb.get('nhm_seg').tolist()
+    nhm_seg = pdb.get('nhm_seg').data
 
     # First check if any of the requested stream segments exist in the NHM.
     # An intersection of 0 elements can occur when all stream segments are
@@ -217,7 +216,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     # NOTE: It's possible to have a stream segment that does not exist in
     #       tosegment but does exist in nhm_seg (e.g. standalone segment). So
     #       we use nhm_seg to verify at least one of the given segment(s) exist.
-    if dsmost_seg and len(set(dsmost_seg).intersection(nhm_seg)) == 0:
+    if dsmost_seg and len(set(dsmost_seg).intersection(set(nhm_seg))) == 0:
         con.print(f'[red]ERROR[/]: None of the requested stream segments exist in the NHM')
         bandit_log.error('None of the requested stream segments exist in the NHM paramDb')
         exit(200)
@@ -240,7 +239,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     dag_ds_subset = subset_stream_network(dag_ds, uscutoff_seg, dsmost_seg)
 
     # Segments in model subset
-    new_nhm_seg = [ee[0] for ee in dag_ds_subset.edges]
+    new_nhm_seg = np.array([ee[0] for ee in dag_ds_subset.edges])
     con.print(f'[green4]INFO[/]: Number of stream segments in model subset: {len(new_nhm_seg)}')
     bandit_log.info(f'Number of segments in model subset: {len(new_nhm_seg)}')
     if verbose:
@@ -257,10 +256,10 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     #                 ordered 1..nhru. This is not always the case so the nhm_id parameter
     #                 needs to be loaded and used to map the nhm HRU ids to their
     #                 respective indices.
-    hru_segment = pdb.get('hru_segment_nhm').tolist()
-    nhm_id = pdb.get('nhm_id').tolist()
+    hru_segment = pdb.get('hru_segment_nhm').data
+    nhm_id = pdb.get('nhm_id').data
     nhm_id_to_idx = pdb.get('nhm_id').index_map
-    bandit_log.info(f'Number of NHM hru_segment entries: {len(hru_segment)}')
+    bandit_log.info(f'Number of NHM hru_segment entries: {hru_segment.size}')
 
     # Create a dictionaries mapping hru_segment segments to hru_segment 1-based indices filtered by
     # new_nhm_seg and hru_noroute.
@@ -290,15 +289,6 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     # new_hru_segment contains the in-order indices for the subset of tosegments
     # --------------------------------------------------------------------------
 
-    # ==========================================================================
-    # ==========================================================================
-    # Get subset of hru_deplcrv using hru_order_subset
-    # A single snarea_curve can be referenced by multiple HRUs
-    hru_deplcrv_subset = pdb.get_subset('hru_deplcrv', hru_order_subset)
-
-    # noinspection PyTypeChecker
-    uniq_deplcrv: List = np.unique(hru_deplcrv_subset).tolist()  # type: ignore
-
     # @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Subset poi_gage_segment
@@ -309,96 +299,10 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
 
     con.print(f'[green4]INFO[/]: Number of POI gages in model subset: {len(new_poi_gage_id)}')
 
-    # ==================================================================
-    # ==================================================================
     # Process the parameters and create a parameter file for the subset
-    params = list(pdb.keys())
-
-    # Remove the POI-related parameters if we have no POIs
-    if len(new_poi_gage_segment) == 0:
-        con.print('[gold3]WARNING[/]: No POIs found for model subset')
-        bandit_log.warning('No POI gages found for subset; removing POI-related parameters.')
-
-        for rp in ['poi_gage_id', 'poi_gage_segment', 'poi_type']:
-            if rp in params:
-                params.remove(rp)
-
-    params.sort()
-
-    # Build dictionary of resized dimensions for the model subset
-    dims = resize_dims(src_global_dims=nhm_global_dimensions.values(),
-                       num_hru=len(hru_order_subset),
-                       num_seg=len(new_nhm_seg),
-                       num_deplcrv=len(uniq_deplcrv),
-                       num_poi=len(new_poi_gage_segment))
-
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Build Parameters for extracted model
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    new_ps = Parameters(metadata=prms_meta)
-
-    # Add the global dimensions
-    for dd, dv in dims.items():
-        new_ps.dimensions.add(dd, dv)
-
-    for pp in params:
-        src_param = pdb.get(pp)
-
-        new_ps.add(name=pp)
-        cnew_param = new_ps.get(pp)
-
-        ndims = src_param.ndim
-        dim_order = list(src_param.dimensions.keys())
-
-        first_dimension = dim_order[0]
-        outdata = None
-
-        # Write out the data for the parameter
-        if ndims == 0:
-            # Scalar parameters
-            outdata = src_param.data
-        elif ndims == 1:
-            # 1D Parameters
-            # if first_dimension == 'one':
-            #     outdata = src_param.data
-            if first_dimension == 'nsegment':
-                if pp in ['tosegment']:
-                    outdata = np.array(new_tosegment)
-                else:
-                    outdata = pdb.get_subset(pp, new_nhm_seg)
-            elif first_dimension == 'ndeplval':
-                # snarea_thresh - this is really a 2D in disguise, however,
-                # it is stored in C-order unlike other 2D arrays
-                outdata = pdb.get_subset(pp, hru_order_subset)
-            elif first_dimension == 'npoigages':
-                if pp == 'poi_gage_segment':
-                    outdata = np.array(new_poi_gage_segment)
-                elif pp == 'poi_gage_id':
-                    outdata = np.array(new_poi_gage_id)
-                elif pp == 'poi_type':
-                    outdata = np.array(new_poi_type)
-                else:
-                    bandit_log.error(f'Unkown parameter, {pp}, with dimensions {first_dimension}')
-            elif first_dimension in HRU_DIMS:
-                if pp == 'hru_deplcrv':
-                    outdata = pdb.get_subset(pp, hru_order_subset)
-                elif pp == 'hru_segment':
-                    outdata = np.array(new_hru_segment)
-                else:
-                    outdata = pdb.get_subset(pp, hru_order_subset)
-            else:
-                bandit_log.error(f'No rules to handle dimension {first_dimension}')
-        elif ndims == 2:
-            # 2D Parameters
-            if first_dimension == 'nsegment':
-                outdata = pdb.get_subset(pp, new_nhm_seg)
-            elif first_dimension in HRU_DIMS:
-                outdata = pdb.get_subset(pp, hru_order_subset)
-            else:
-                err_txt = f'No rules to handle 2D parameter, {pp}, which contains dimension {first_dimension}'
-                bandit_log.error(err_txt)
-
-        cnew_param.data = outdata
+    new_ps = create_parameter_subset(prms_meta, pdb, hru_order_subset,
+                                     new_hru_segment, new_nhm_seg, new_poi_gage_id,
+                                     new_poi_gage_segment, new_poi_type, new_tosegment)
 
     # Write the new parameter file
     if verbose:
@@ -520,8 +424,9 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
                     mydyn.read_netcdf()
                     out_order = [kk for kk in hru_order_subset]
 
-                    for cc in ['day', 'month', 'year']:
-                        out_order.insert(0, cc)
+                    out_order = ['year', 'month', 'day'] + out_order
+                    # for cc in ['day', 'month', 'year']:
+                    #     out_order.insert(0, cc)
 
                     header = ' '.join(map(str, out_order))   # type: ignore
 

--- a/Bandit/bandit_cfg.py
+++ b/Bandit/bandit_cfg.py
@@ -5,6 +5,7 @@
 # Description: Configuration class for Model Bandit
 #              YAML is used for the backend
 
+import datetime
 import ruamel.yaml
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any
@@ -106,6 +107,8 @@ class Cfg(object):
         if isinstance(cval, str):
             return len(cval) == 0
         if isinstance(cval, bool):
+            return False
+        if isinstance(cval, datetime.date):
             return False
         return True
 

--- a/Bandit/bandit_helpers.py
+++ b/Bandit/bandit_helpers.py
@@ -5,9 +5,11 @@ import networkx as nx   # type: ignore
 import numpy as np
 import re
 
-from collections import OrderedDict
 from typing import Union, Dict, List, Set, Tuple
 
+from pyPRMS.base.console import get_console_instance
+# from pyPRMS.metadata.metadata import MetaData
+from pyPRMS import Parameters   # type: ignore
 from pyPRMS.constants import HRU_DIMS
 
 logger = logging.getLogger(__name__)
@@ -149,29 +151,180 @@ def subset_stream_network(dag_ds: nx.classes.digraph.DiGraph,
 
     return dag_ds_subset
 
+def create_parameter_subset(prms_meta,
+                            pdb,
+                            hru_order_subset,
+                            new_hru_segment,
+                            new_nhm_seg,
+                            new_poi_gage_id,
+                            new_poi_gage_segment,
+                            new_poi_type,
+                            new_tosegment):
+
+    # Rich library
+    con = get_console_instance(record=True)
+
+    nhm_global_dimensions = pdb.dimensions
+
+    # ==========================================================================
+    # ==========================================================================
+    # Get subset of hru_deplcrv using hru_order_subset
+    # A single snarea_curve can be referenced by multiple HRUs
+    hru_deplcrv_subset = pdb.get_subset('hru_deplcrv', hru_order_subset)
+
+    # noinspection PyTypeChecker
+    uniq_deplcrv: List = np.unique(hru_deplcrv_subset).tolist()  # type: ignore
+
+    # ==================================================================
+    # ==================================================================
+    # Process the parameters and create a parameter file for the subset
+    params = list(pdb.keys())
+
+    # Remove the POI-related parameters if we have no POIs
+    if len(new_poi_gage_segment) == 0:
+        con.print('[gold3]WARNING[/]: No POIs found for model subset')
+        # bandit_log.warning('No POI gages found for subset; removing POI-related parameters.')
+
+        for rp in ['poi_gage_id', 'poi_gage_segment', 'poi_type']:
+            if rp in params:
+                params.remove(rp)
+
+    params.sort()
+
+    # Build dictionary of resized dimensions for the model subset
+    dims = resize_dims(src_global_dims=nhm_global_dimensions.values(),
+                       num_hru=len(hru_order_subset),
+                       num_seg=len(new_nhm_seg),
+                       num_deplcrv=len(uniq_deplcrv),
+                       num_poi=len(new_poi_gage_segment))
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Build Parameters for extracted model
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    new_ps = Parameters(metadata=prms_meta)
+
+    # Add the global dimensions
+    for dd, dv in dims.items():
+        new_ps.dimensions.add(dd, dv)
+
+    for pp in params:
+        src_param = pdb.get(pp)
+
+        new_ps.add(name=pp)
+        cnew_param = new_ps.get(pp)
+
+        ndims = src_param.ndim
+        dim_order = list(src_param.dimensions.keys())
+
+        first_dimension = dim_order[0]
+        outdata = None
+
+        # Write out the data for the parameter
+        if ndims == 0:
+            # Scalar parameters
+            outdata = src_param.data
+        elif ndims == 1:
+            # 1D Parameters
+            # if first_dimension == 'one':
+            #     outdata = src_param.data
+            if first_dimension == 'nsegment':
+                if pp in ['tosegment']:
+                    outdata = np.array(new_tosegment)
+                else:
+                    outdata = pdb.get_subset(pp, new_nhm_seg)
+            elif first_dimension == 'ndeplval':
+                # snarea_thresh - this is really a 2D in disguise, however,
+                # it is stored in C-order unlike other 2D arrays
+                outdata = pdb.get_subset(pp, hru_order_subset)
+            elif first_dimension == 'npoigages':
+                if pp == 'poi_gage_segment':
+                    outdata = np.array(new_poi_gage_segment)
+                elif pp == 'poi_gage_id':
+                    outdata = np.array(new_poi_gage_id)
+                elif pp == 'poi_type':
+                    outdata = np.array(new_poi_type)
+                else:
+                    con.print(f'[red]ERROR[/]: Unkown parameter, {pp}, with dimensions {first_dimension}')
+                    # bandit_log.error(f'Unkown parameter, {pp}, with dimensions {first_dimension}')
+            elif first_dimension in HRU_DIMS:
+                if pp == 'hru_deplcrv':
+                    outdata = pdb.get_subset(pp, hru_order_subset)
+                elif pp == 'hru_segment':
+                    outdata = np.array(new_hru_segment)
+                else:
+                    outdata = pdb.get_subset(pp, hru_order_subset)
+            else:
+                con.print(f'[red]ERROR[/]: No rules to handle dimension {first_dimension}')
+                # bandit_log.error(f'No rules to handle dimension {first_dimension}')
+        elif ndims == 2:
+            # 2D Parameters
+            if first_dimension == 'nsegment':
+                outdata = pdb.get_subset(pp, new_nhm_seg)
+            elif first_dimension in HRU_DIMS:
+                outdata = pdb.get_subset(pp, hru_order_subset)
+            else:
+                err_txt = f'No rules to handle 2D parameter, {pp}, which contains dimension {first_dimension}'
+                con.print(f'[red]ERROR[/]: {err_txt}')
+                # bandit_log.error(err_txt)
+
+        cnew_param.data = outdata
+
+    return new_ps
+
 
 def get_hru_and_seg_subset_maps(orig_hru_segment, orig_nhm_id, nhm_seg_subset, hru_noroute):
     # Create a dictionary mapping hru_segment segments to hru_segment 1-based indices filtered by
     # new_nhm_seg and hru_noroute.
+    # Assumes all inputs are numpy arrays
     seg_to_hru = dict()
     hru_to_seg = dict()
 
-    for ii, vv in enumerate(orig_hru_segment):
-        # Contains both new_nhm_seg values and non-routed HRU values
-        # keys are 1-based, values in arrays are 1-based
-        hid = orig_nhm_id[ii]
-        if vv in nhm_seg_subset:
-            seg_to_hru.setdefault(vv, []).append(hid)
-            hru_to_seg[hid] = vv
-        elif hid in hru_noroute:
-            if vv != 0:
-                err_txt = f'User-supplied non-routed HRU {hid} that routes to stream segment {vv}; skipping.'
-                logger.error(err_txt)
-            else:
-                seg_to_hru.setdefault(vv, []).append(hid)
-                hru_to_seg[hid] = vv
+    # Create boolean masks for efficient filtering
+    in_seg_subset = np.isin(orig_hru_segment, nhm_seg_subset)
+    in_hru_noroute = np.isin(orig_nhm_id, hru_noroute)
+
+    # Process in original order to maintain ordering
+    for ii in range(len(orig_hru_segment)):
+      vv = orig_hru_segment[ii]
+      hid = orig_nhm_id[ii]
+
+      if in_seg_subset[ii]:
+          seg_to_hru.setdefault(vv, []).append(hid)
+          hru_to_seg[hid] = vv
+      elif in_hru_noroute[ii]:
+          if vv != 0:
+              err_txt = f'User-supplied non-routed HRU {hid} that routes to stream segment {vv}; skipping.'
+              logger.error(err_txt)
+          else:
+              seg_to_hru.setdefault(vv, []).append(hid)
+              hru_to_seg[hid] = vv
 
     return seg_to_hru, hru_to_seg
+
+
+# def get_hru_and_seg_subset_maps(orig_hru_segment, orig_nhm_id, nhm_seg_subset, hru_noroute):
+#     # Create a dictionary mapping hru_segment segments to hru_segment 1-based indices filtered by
+#     # new_nhm_seg and hru_noroute.
+#     seg_to_hru = dict()
+#     hru_to_seg = dict()
+#
+#     for ii, vv in enumerate(orig_hru_segment):
+#         # Contains both new_nhm_seg values and non-routed HRU values
+#         # keys are 1-based, values in arrays are 1-based
+#         hid = orig_nhm_id[ii]
+#
+#         if vv in nhm_seg_subset:
+#             seg_to_hru.setdefault(vv, []).append(hid)
+#             hru_to_seg[hid] = vv
+#         elif hid in hru_noroute:
+#             if vv != 0:
+#                 err_txt = f'User-supplied non-routed HRU {hid} that routes to stream segment {vv}; skipping.'
+#                 logger.error(err_txt)
+#             else:
+#                 seg_to_hru.setdefault(vv, []).append(hid)
+#                 hru_to_seg[hid] = vv
+#
+#     return seg_to_hru, hru_to_seg
 
 
 def get_output_order(hru_to_seg, seg_to_hru, orig_hru_segment, orig_nhm_id_to_idx,
@@ -182,7 +335,7 @@ def get_output_order(hru_to_seg, seg_to_hru, orig_hru_segment, orig_nhm_id_to_id
         # NOTE: Segments that have no HRUs connected to them are not logged
         hru_order_subset = [kk for kk in hru_to_seg.keys()]
 
-        new_hru_segment = [new_nhm_seg_to_idx1[kk] if kk in new_nhm_seg else 0 if kk == 0 else -1 for kk in
+        new_hru_segment = [new_nhm_seg_to_idx1[kk] if kk in set(new_nhm_seg) else 0 if kk == 0 else -1 for kk in
                            hru_to_seg.values()]
     else:
         # Get NHM HRU ids ordered by the segments in the model subset - indices are 1-based

--- a/Bandit/bandit_helpers.py
+++ b/Bandit/bandit_helpers.py
@@ -314,20 +314,20 @@ def get_hru_and_seg_subset_maps(orig_hru_segment: ParamDataType,
     in_hru_noroute = np.isin(orig_nhm_id, hru_noroute)
 
     # Process in original order to maintain ordering
-    for ii in range(len(orig_hru_segment)):
-      vv = orig_hru_segment[ii]
-      hid = orig_nhm_id[ii]
+    for cidx in range(len(orig_hru_segment)):
+      cseg = orig_hru_segment[cidx]
+      hid = orig_nhm_id[cidx]
 
-      if in_seg_subset[ii]:
-          seg_to_hru.setdefault(vv, []).append(hid)
-          hru_to_seg[hid] = vv
-      elif in_hru_noroute[ii]:
-          if vv != 0:
-              err_txt = f'User-supplied non-routed HRU {hid} that routes to stream segment {vv}; skipping.'
+      if in_seg_subset[cidx]:
+          seg_to_hru.setdefault(cseg, []).append(hid)
+          hru_to_seg[hid] = cseg
+      elif in_hru_noroute[cidx]:
+          if cseg != 0:
+              err_txt = f'User-supplied non-routed HRU {hid} that routes to stream segment {cseg}; skipping.'
               logger.error(err_txt)
           else:
-              seg_to_hru.setdefault(vv, []).append(hid)
-              hru_to_seg[hid] = vv
+              seg_to_hru.setdefault(cseg, []).append(hid)
+              hru_to_seg[hid] = cseg
 
     return seg_to_hru, hru_to_seg
 
@@ -336,7 +336,6 @@ def get_output_order(hru_to_seg: Dict[int, int],
                      seg_to_hru: Dict[int, List[int]],
                      orig_hru_segment: ParamDataType,
                      orig_nhm_id_to_idx: Dict[int, int],
-                     new_nhm_seg: NDArray,
                      new_nhm_seg_to_idx1: Dict[int, int],
                      hru_noroute: NDArray,
                      keep_hru_order: bool = False) -> Tuple[List[int], List[int]]:
@@ -346,7 +345,6 @@ def get_output_order(hru_to_seg: Dict[int, int],
     :param seg_to_hru: Dictionary mapping segments to HRUs
     :param orig_hru_segment: NHM HRU segments from source parameter database
     :param orig_nhm_id_to_idx: Dictionary mapping NHM HRU IDs to indices in the source parameter database
-    :param new_nhm_seg: Array of segment IDs for parameter subset
     :param new_nhm_seg_to_idx1: Dictionary mapping segment IDs to 1-based indices in the subset
     :param hru_noroute: Array of non-routed HRUs to include in parameter subset
     :param keep_hru_order: If True, keep the original HRU-relative order in the model subset
@@ -359,56 +357,67 @@ def get_output_order(hru_to_seg: Dict[int, int],
         # NOTE: Segments that have no HRUs connected to them are not logged
         hru_order_subset = [kk for kk in hru_to_seg.keys()]
 
-        new_hru_segment = [new_nhm_seg_to_idx1[kk] if kk in set(new_nhm_seg) else 0 if kk == 0 else -1 for kk in
-                           hru_to_seg.values()]
+        new_hru_segment = []
+
+        for cseg in hru_to_seg.values():
+            if cseg in new_nhm_seg_to_idx1:
+                new_hru_segment.append(new_nhm_seg_to_idx1[cseg])
+            elif cseg == 0:
+                new_hru_segment.append(0)
+            else:
+                new_hru_segment.append(-1)
     else:
         # Get NHM HRU ids ordered by the segments in the model subset - indices are 1-based
         hru_order_subset = []
-        for xx in new_nhm_seg:
-            if xx in seg_to_hru:
-                for yy in seg_to_hru[xx]:
-                    hru_order_subset.append(yy)
+        for cseg in new_nhm_seg_to_idx1.keys():
+            if cseg in seg_to_hru:
+                for chru in seg_to_hru[cseg]:
+                    hru_order_subset.append(chru)
             else:
-                logger.warning(f'Stream segment {xx} has no HRUs connected to it.')
+                logger.warning(f'Stream segment {cseg} has no HRUs connected to it.')
 
         # Append the additional non-routed HRUs to the list
         if len(hru_noroute) > 0:
-            for xx in hru_noroute:
-                if orig_hru_segment[orig_nhm_id_to_idx[xx]] == 0:
-                    logger.info(f'User-supplied HRU {xx} is not connected to any stream segment')
-                    hru_order_subset.append(xx)
+            for cseg in hru_noroute:
+                if orig_hru_segment[orig_nhm_id_to_idx[cseg]] == 0:
+                    logger.info(f'User-supplied HRU {cseg} is not connected to any stream segment')
+                    hru_order_subset.append(cseg)
                 else:
-                    err_txt = f'User-supplied HRU {xx} routes to stream segment ' + \
-                              f'{orig_hru_segment[orig_nhm_id_to_idx[xx]]} - Skipping.'
+                    err_txt = f'User-supplied HRU {cseg} routes to stream segment ' + \
+                              f'{orig_hru_segment[orig_nhm_id_to_idx[cseg]]} - Skipping.'
                     logger.error(err_txt)
 
-        # Renumber the hru_segments for the subset
-        new_hru_segment = []
-
-        for xx in new_nhm_seg:
-            if xx in seg_to_hru:
-                for _ in seg_to_hru[xx]:
-                    # The new indices should be 1-based from PRMS
-                    new_hru_segment.append(new_nhm_seg_to_idx1[xx])
-
-        # Append zeroes to new_hru_segment for each additional non-routed HRU
-        if len(hru_noroute) > 0:
-            for xx in hru_noroute:
-                if orig_hru_segment[orig_nhm_id_to_idx[xx]] == 0:
-                    new_hru_segment.append(0)
-
+        new_hru_segment = _renumber_hru_segments(seg_to_hru, orig_hru_segment, orig_nhm_id_to_idx,
+                                                 new_nhm_seg_to_idx1, hru_noroute)
     return hru_order_subset, new_hru_segment
 
 
+def _renumber_hru_segments(seg_to_hru, orig_hru_segment, orig_nhm_id_to_idx,
+                           new_nhm_seg_to_idx1, hru_noroute):
+    # Renumber the hru_segments for the subset
+    new_hru_segment = []
+
+    for cseg, cidx in new_nhm_seg_to_idx1.items():
+        if cseg in seg_to_hru:
+            for _ in seg_to_hru[cseg]:
+                # The new indices should be 1-based from PRMS
+                new_hru_segment.append(cidx)
+
+    # Append zeroes to new_hru_segment for each additional non-routed HRU
+    if len(hru_noroute) > 0:
+        for cseg in hru_noroute:
+            if orig_hru_segment[orig_nhm_id_to_idx[cseg]] == 0:
+                new_hru_segment.append(0)
+    return new_hru_segment
+
+
 def get_poi_subset(nhm_params: Parameters,
-                   new_nhm_seg: NDArray,
                    new_nhm_seg_to_idx1: Dict[int, int],
                    seg_to_hru: Dict[int, List[int]],
                    addl_gages: Optional[Dict]  = None) -> Tuple[List[int], List[str], List[int]]:
     """Create lists of POI IDs, segments, and types for a model subset.
 
     :param nhm_params: Source NHM parameter database
-    :param new_nhm_seg: Array of segment IDs for parameter subset
     :param new_nhm_seg_to_idx1: Dictionary mapping segment IDs to 1-based indices in the subset
     :param seg_to_hru: Dictionary mapping segments to HRUs
     :param addl_gages: Dictionary additional streamgages to include in the subset
@@ -436,7 +445,7 @@ def get_poi_subset(nhm_params: Parameters,
         nhm_seg_dict = nhm_params.get('nhm_seg').index_map
         poi_gage_dict = nhm_params.get('poi_gage_segment').index_map
 
-        for ss in new_nhm_seg:
+        for ss in new_nhm_seg_to_idx1.keys():
             sidx = nhm_seg_dict[ss] + 1
             if sidx in poi_gage_segment:
                 # print('   {}'.format(poi_gage_segment.index(sidx)))

--- a/Bandit/bandit_helpers.py
+++ b/Bandit/bandit_helpers.py
@@ -5,11 +5,13 @@ import networkx as nx   # type: ignore
 import numpy as np
 import re
 
-from typing import Union, Dict, List, Set, Tuple
+from numpy.typing import NDArray
+from typing import Union, Dict, List, Optional, Set, Tuple
 
 from pyPRMS.base.console import get_console_instance
-# from pyPRMS.metadata.metadata import MetaData
+from pyPRMS.constants import MetaDataType
 from pyPRMS import Parameters   # type: ignore
+from pyPRMS.parameters.Parameter import ParamDataType
 from pyPRMS.constants import HRU_DIMS
 
 logger = logging.getLogger(__name__)
@@ -151,20 +153,34 @@ def subset_stream_network(dag_ds: nx.classes.digraph.DiGraph,
 
     return dag_ds_subset
 
-def create_parameter_subset(prms_meta,
-                            pdb,
-                            hru_order_subset,
-                            new_hru_segment,
-                            new_nhm_seg,
-                            new_poi_gage_id,
-                            new_poi_gage_segment,
-                            new_poi_type,
-                            new_tosegment):
+
+def create_parameter_subset(prms_meta: MetaDataType,
+                            pdb: Parameters,
+                            hru_order_subset: List[int],
+                            new_hru_segment: List[int],
+                            new_nhm_seg: List[int],
+                            new_poi_gage_id: List[str],
+                            new_poi_gage_segment: List[int],
+                            new_poi_type: List[int],
+                            new_tosegment: List[int]):
+    """Create a new Parameters object that is a subset of the original parameter database.
+
+    :param prms_meta: PRMS metadata object
+    :param pdb: Original parameter database
+    :param hru_order_subset: List of HRUs to include in the subset
+    :param new_hru_segment: List of HRUs segments for HRUs subset
+    :param new_nhm_seg: List of NHM segments for subset
+    :param new_poi_gage_id: List of POI gage ids for subset
+    :param new_poi_gage_segment: List of POI gage segments for subset
+    :param new_poi_type: List of POI types for subset
+    :param new_tosegment: List of tosegment values for subset
+    :return: New Parameters object with subset of parameters
+    """
 
     # Rich library
     con = get_console_instance(record=True)
 
-    nhm_global_dimensions = pdb.dimensions
+    # nhm_global_dimensions = pdb.dimensions
 
     # ==========================================================================
     # ==========================================================================
@@ -192,7 +208,8 @@ def create_parameter_subset(prms_meta,
     params.sort()
 
     # Build dictionary of resized dimensions for the model subset
-    dims = resize_dims(src_global_dims=nhm_global_dimensions.values(),
+    # dims = resize_dims(src_global_dims=nhm_global_dimensions.values(),
+    dims = resize_dims(pdb=pdb,
                        num_hru=len(hru_order_subset),
                        num_seg=len(new_nhm_seg),
                        num_deplcrv=len(uniq_deplcrv),
@@ -272,7 +289,20 @@ def create_parameter_subset(prms_meta,
     return new_ps
 
 
-def get_hru_and_seg_subset_maps(orig_hru_segment, orig_nhm_id, nhm_seg_subset, hru_noroute):
+def get_hru_and_seg_subset_maps(orig_hru_segment: ParamDataType,
+                                orig_nhm_id: ParamDataType,
+                                nhm_seg_subset: NDArray,
+                                hru_noroute: NDArray) -> Tuple[Dict[int, List[int]], Dict[int, int]]:
+    """Create a dictionary mapping hru_segment segments to hru_segment 1-based indices filtered by
+    new_nhm_seg and hru_noroute.
+
+    :param orig_hru_segment: NHM HRU segments from source parameter database
+    :param orig_nhm_id: NHM HRU IDs from source parameter database
+    :param nhm_seg_subset: Array of segment IDs for parameter subset
+    :param hru_noroute: Array of non-routed HRUs to include in parameter subset
+    :return: Dictionaries mapping segments-to-HRUs and HRUs-to-segments
+    """
+
     # Create a dictionary mapping hru_segment segments to hru_segment 1-based indices filtered by
     # new_nhm_seg and hru_noroute.
     # Assumes all inputs are numpy arrays
@@ -302,33 +332,27 @@ def get_hru_and_seg_subset_maps(orig_hru_segment, orig_nhm_id, nhm_seg_subset, h
     return seg_to_hru, hru_to_seg
 
 
-# def get_hru_and_seg_subset_maps(orig_hru_segment, orig_nhm_id, nhm_seg_subset, hru_noroute):
-#     # Create a dictionary mapping hru_segment segments to hru_segment 1-based indices filtered by
-#     # new_nhm_seg and hru_noroute.
-#     seg_to_hru = dict()
-#     hru_to_seg = dict()
-#
-#     for ii, vv in enumerate(orig_hru_segment):
-#         # Contains both new_nhm_seg values and non-routed HRU values
-#         # keys are 1-based, values in arrays are 1-based
-#         hid = orig_nhm_id[ii]
-#
-#         if vv in nhm_seg_subset:
-#             seg_to_hru.setdefault(vv, []).append(hid)
-#             hru_to_seg[hid] = vv
-#         elif hid in hru_noroute:
-#             if vv != 0:
-#                 err_txt = f'User-supplied non-routed HRU {hid} that routes to stream segment {vv}; skipping.'
-#                 logger.error(err_txt)
-#             else:
-#                 seg_to_hru.setdefault(vv, []).append(hid)
-#                 hru_to_seg[hid] = vv
-#
-#     return seg_to_hru, hru_to_seg
+def get_output_order(hru_to_seg: Dict[int, int],
+                     seg_to_hru: Dict[int, List[int]],
+                     orig_hru_segment: ParamDataType,
+                     orig_nhm_id_to_idx: Dict[int, int],
+                     new_nhm_seg: NDArray,
+                     new_nhm_seg_to_idx1: Dict[int, int],
+                     hru_noroute: NDArray,
+                     keep_hru_order: bool = False) -> Tuple[List[int], List[int]]:
+    """Create lists of HRU ids and HRU segments for a model subset.
 
+    :param hru_to_seg: Dictionary mapping HRUs to segments
+    :param seg_to_hru: Dictionary mapping segments to HRUs
+    :param orig_hru_segment: NHM HRU segments from source parameter database
+    :param orig_nhm_id_to_idx: Dictionary mapping NHM HRU IDs to indices in the source parameter database
+    :param new_nhm_seg: Array of segment IDs for parameter subset
+    :param new_nhm_seg_to_idx1: Dictionary mapping segment IDs to 1-based indices in the subset
+    :param hru_noroute: Array of non-routed HRUs to include in parameter subset
+    :param keep_hru_order: If True, keep the original HRU-relative order in the model subset
+    :return: Lists of HRU ids and HRU segments for the model subset
+    """
 
-def get_output_order(hru_to_seg, seg_to_hru, orig_hru_segment, orig_nhm_id_to_idx,
-                     new_nhm_seg, new_nhm_seg_to_idx1, hru_noroute, keep_hru_order=False):
     # HRU-related parameters can either be output with the legacy, segment-oriented order
     # or can be output maintaining their original HRU-relative order from the parameter database.
     if keep_hru_order:
@@ -376,7 +400,21 @@ def get_output_order(hru_to_seg, seg_to_hru, orig_hru_segment, orig_nhm_id_to_id
     return hru_order_subset, new_hru_segment
 
 
-def get_poi_subset(nhm_params, new_nhm_seg, new_nhm_seg_to_idx1, seg_to_hru, addl_gages=None):
+def get_poi_subset(nhm_params: Parameters,
+                   new_nhm_seg: NDArray,
+                   new_nhm_seg_to_idx1: Dict[int, int],
+                   seg_to_hru: Dict[int, List[int]],
+                   addl_gages: Optional[Dict]  = None) -> Tuple[List[int], List[str], List[int]]:
+    """Create lists of POI IDs, segments, and types for a model subset.
+
+    :param nhm_params: Source NHM parameter database
+    :param new_nhm_seg: Array of segment IDs for parameter subset
+    :param new_nhm_seg_to_idx1: Dictionary mapping segment IDs to 1-based indices in the subset
+    :param seg_to_hru: Dictionary mapping segments to HRUs
+    :param addl_gages: Dictionary additional streamgages to include in the subset
+    :return: Lists of POI IDs, segments, and types for the model subset
+    """
+
     # Subset poi_gage_segment
     new_poi_gage_segment = []
     new_poi_gage_id = []
@@ -439,8 +477,22 @@ def get_poi_subset(nhm_params, new_nhm_seg, new_nhm_seg_to_idx1, seg_to_hru, add
     return new_poi_gage_segment, new_poi_gage_id, new_poi_type
 
 
-def resize_dims(src_global_dims, num_hru, num_seg, num_deplcrv, num_poi):
-    dims = {kk.name: kk.size for kk in src_global_dims}
+def resize_dims(pdb: Parameters,
+                num_hru: int,
+                num_seg: int,
+                num_deplcrv: int,
+                num_poi: int) -> Dict[str, int]:
+    """Returns a dictionary of dimensions from the source parameter database resized to the model subset.
+
+    :param pdb: Original parameter database
+    :param num_hru: Number of HRUs in the model subset
+    :param num_seg: Number of segments in the model subset
+    :param num_deplcrv: Number of snow depletion curves in the model subset
+    :param num_poi: Number of Points-of-Interest (POIs) in the model subset
+    :return: Dictionary of the resized dimensions
+    """
+
+    dims = {kk.name: kk.size for kk in pdb.dimensions.values()}
 
     # Resize dimensions to the model subset
     crap_dims = dims.copy()   # need a copy since we modify dims

--- a/Bandit/bandit_single_hru.py
+++ b/Bandit/bandit_single_hru.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 
-import argparse
 import datetime
 import errno
 import logging
 import numpy as np
 import os
-import sys
 import time
 
 from cyclopts import App, Parameter, validators
@@ -17,7 +15,7 @@ from typing import Annotated, List, Optional, Union
 from pyPRMS.base.console import get_console_instance
 
 from Bandit import __version__
-from Bandit.bandit_helpers import set_date, resize_dims
+from Bandit.bandit_helpers import create_parameter_subset, set_date
 from Bandit.git_version import git_commit, git_repo, git_branch, git_commit_url
 from Bandit.model_output import ModelOutput
 import Bandit.bandit_cfg as bc   # type: ignore
@@ -116,7 +114,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     param_filename = Path(config.param_filename)   # Name of the output parameter file
     paramdb_dir = Path(config.paramdb_dir)   # Location of the NHM parameter database
     cbh_dir = Path(config.cbh_dir)
-    hru_noroute = config.hru_noroute   # List of additional HRUs (have no route to segment within subset)
+    hru_noroute = np.array(config.hru_noroute)   # Array of additional HRUs (have no route to segment within subset)
 
     # if prms_version == 6:
     #     cbh_netcdf = True
@@ -139,6 +137,15 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     ctl.get('start_time').values = st_date
     ctl.get('end_time').values = en_date
 
+    # Default the various *ON_OFF variables to 0 (off)
+    # The original values are needed to reduce parameters by module,
+    # but it's best to disable them in the final control file since
+    # no output variables are defined for them.
+    disable_vars = ['basinOutON_OFF', 'csvON_OFF', 'mapOutON_OFF', 'nhruOutON_OFF',
+                    'nsegmentOutON_OFF', 'nsubOutON_OFF']
+    for vv in disable_vars:
+        ctl.get(vv).values = 0
+
     # Output revision of NhmParamDb
     git_url = git_commit_url(paramdb_dir)
     nhmparamdb_revision = git_commit(paramdb_dir, length=7)
@@ -148,7 +155,6 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
 
     # Load the NHMparamdb
     if verbose:
-        # con.print('[green4]INFO[/]: Loading NHM ParamDb')
         con.print(f'[green4]INFO[/]: Parameter database: {git_repo(paramdb_dir)}')
         con.print(f'[green4]INFO[/]: Branch: {git_branch(paramdb_dir)}')
         con.print(f'[green4]INFO[/]: Commit: {nhmparamdb_revision}')
@@ -162,17 +168,6 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     if not no_filter_params:
         # Reduce the parameters to those required by the selected modules
         pdb.remove(pdb.unneeded_parameters)
-
-    # Default the various *ON_OFF variables to 0 (off)
-    # The original values are needed to reduce parameters by module,
-    # but it's best to disable them in the final control file since
-    # no output variables are defined for them.
-    disable_vars = ['basinOutON_OFF', 'csvON_OFF', 'mapOutON_OFF', 'nhruOutON_OFF',
-                    'nsegmentOutON_OFF', 'nsubOutON_OFF']
-    for vv in disable_vars:
-        ctl.get(vv).values = 0
-
-    nhm_global_dimensions = pdb.dimensions
 
     # Trim paramdb parameters for single-HRU extractions
     params = list(pdb.keys())
@@ -204,9 +199,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     # Now remove those parameters
     for rp in remove_params:
         if rp in params:
-            params.remove(rp)
-
-    params.sort()
+            pdb.remove(rp)
 
     # ====================================================================
     # ====================================================================
@@ -250,92 +243,18 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
         # ==================================================================
         # ==================================================================
         # Process the parameters and create a parameter file for the subset
-        params = list(pdb.keys())
 
-        # Remove the POI-related parameters
-        for rp in remove_params:
-            if rp in params:
-                params.remove(rp)
-
-        params.sort()
-
-        # Build dictionary of resized dimensions for the model subset
-        dims = resize_dims(src_global_dims=nhm_global_dimensions.values(),
-                           num_hru=len(hru_order_subset),
-                           num_seg=len(new_nhm_seg),
-                           num_deplcrv=len(uniq_deplcrv),
-                           num_poi=0)
-
-        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        # Build Parameters for extracted model
-        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        new_ps = Parameters(metadata=prms_meta)
-
-        # Add the global dimensions
-        for dd, dv in dims.items():
-            new_ps.dimensions.add(dd, dv)
-
-        for pp in params:
-            src_param = pdb.get(pp)
-
-            # if args.verbose:
-            #     sys.stdout.write('\r                                       ')
-            #     sys.stdout.write(f'\rProcessing {src_param.name} ')
-            #     sys.stdout.flush()
-
-            new_ps.add(name=pp)
-            cnew_param = new_ps.get(pp)
-
-            ndims = src_param.ndim
-            dim_order = list(src_param.dimensions.keys())
-
-            first_dimension = dim_order[0]
-            outdata = None
-
-            # Write out the data for the parameter
-            if ndims == 0:
-                # Scalar parameters
-                outdata = src_param.data
-            elif ndims == 1:
-                # 1D Parameters
-                if first_dimension == 'one':
-                    outdata = src_param.data
-                elif include_stream and first_dimension == 'nsegment':
-                    if pp in ['tosegment']:
-                        outdata = np.array(0)
-                    else:
-                        outdata = pdb.get_subset(pp, new_nhm_seg)
-                elif first_dimension == 'ndeplval':
-                    # snarea_thresh - this is really a 2D in disguise, however,
-                    # it is stored in C-order unlike other 2D arrays
-                    outdata = pdb.get_subset(pp, hru_order_subset)
-                elif first_dimension in HRU_DIMS:
-                    if pp == 'hru_deplcrv':
-                        outdata = pdb.get_subset(pp, hru_order_subset)
-                    elif pp == 'hru_segment':
-                        if include_stream:
-                            outdata = np.array(1)
-                        else:
-                            print(f'ERROR: {src_param.name} should not be here')
-                            pass
-                    else:
-                        outdata = pdb.get_subset(pp, hru_order_subset)
-                else:
-                    bandit_log.error(f'No rules to handle dimension {first_dimension}')
-            elif ndims == 2:
-                # 2D Parameters
-                if first_dimension == 'nsegment':
-                    if include_stream:
-                        outdata = pdb.get_subset(pp, new_nhm_seg)
-                    else:
-                        print(f'ERROR: {src_param.name} should not be here')
-                elif first_dimension in HRU_DIMS:
-                    outdata = pdb.get_subset(pp, hru_order_subset)
-                else:
-                    err_txt = f'No rules to handle 2D parameter, {pp}, which contains dimension {first_dimension}'
-                    bandit_log.error(err_txt)
-
-            cnew_param.data = outdata
+        # The following 5 variables are not used for single-HRU extractions
+        new_hru_segment = []
+        new_poi_gage_id = []
+        new_poi_gage_segment = []
+        new_poi_type = []
+        new_tosegment = []
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # Process the parameters and create a parameter file for the subset
+        new_ps = create_parameter_subset(prms_meta, pdb, hru_order_subset,
+                                         new_hru_segment, new_nhm_seg, new_poi_gage_id,
+                                         new_poi_gage_segment, new_poi_type, new_tosegment)
 
         # We're far enough along without error to go ahead and make the directory
         try:
@@ -361,12 +280,6 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
             new_ps.write_parameter_file(sg_dir / param_filename, header=header)
 
         ctl.get('param_file').values = str(param_filename)
-
-        # if args.verbose:
-        #     sys.stdout.write('\n')
-        #     sys.stdout.write('\r                                       ')
-        #     sys.stdout.write('\r\tParameter file written: {}\n'.format('{}/{}'.format(outdir, param_filename)))
-        # sys.stdout.flush()
 
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Write CBH files

--- a/Bandit/config_validator.py
+++ b/Bandit/config_validator.py
@@ -1,0 +1,233 @@
+"""Configuration validator for Bandit.
+
+Validates a Bandit Cfg object before extraction begins, collecting all
+errors in a single pass so the modeler can fix every issue at once.
+"""
+
+import datetime
+from typing import List, Set
+
+from Bandit.bandit_cfg import Cfg
+
+
+class ConfigValidator:
+    """Validates a Bandit Cfg object before extraction begins."""
+
+    CORE_FIELDS = [
+        'output_dir',
+        'param_filename',
+        'paramdb_dir',
+        'control_filename',
+        'start_date',
+        'end_date',
+    ]
+
+    def __init__(self, config: Cfg):
+        """Initialize the validator.
+
+        :param config: A loaded Cfg instance to validate.
+        """
+        self._config = config
+        self._errors: List[str] = []
+
+    def validate(self) -> List[str]:
+        """Run all validation checks and return a list of error messages.
+
+        Returns an empty list if the configuration is valid.
+        """
+        self._errors = []
+
+        failed_fields = self._validate_core_fields()
+        self._validate_dates()
+        self._validate_paths(failed_fields)
+        self._validate_cbh_fields()
+        self._validate_model_output_fields()
+        self._validate_streamflow_fields()
+        self._validate_gis_fields()
+        self._validate_list_types()
+
+        return self._errors
+
+    def _validate_core_fields(self) -> Set[str]:
+        """Check that core required fields are present and non-empty.
+
+        Returns the set of field names that failed validation, so
+        downstream path checks can skip them.
+        """
+        failed: Set[str] = set()
+
+        for name in self.CORE_FIELDS:
+            if not self._config.exists(name) or self._config.is_empty(name):
+                self._errors.append(f"Required field '{name}' is missing or empty")
+                failed.add(name)
+
+        return failed
+
+    def _validate_dates(self) -> None:
+        """Check date format (YYYY-MM-DD) and that start_date < end_date."""
+        parsed_dates = {}
+
+        for name in ('start_date', 'end_date'):
+            if not self._config.exists(name):
+                # Field doesn't exist at all; skip (caught by core field validation).
+                continue
+
+            value = self._config.get_value(name)
+
+            if isinstance(value, datetime.date) and not isinstance(value, datetime.datetime):
+                # ruamel.yaml may parse bare dates as datetime.date objects.
+                parsed_dates[name] = value
+                continue
+
+            # Skip truly empty values — they'll be caught by core field validation.
+            if value is None or (isinstance(value, str) and value.strip() == ''):
+                continue
+
+            # Value should be a string — try to parse it.
+            try:
+                parsed_dates[name] = datetime.datetime.strptime(str(value), '%Y-%m-%d').date()
+            except (ValueError, TypeError):
+                self._errors.append(
+                    f"Field '{name}' has invalid date format '{value}'; expected YYYY-MM-DD"
+                )
+
+        # Only check ordering if both dates were successfully parsed.
+        if 'start_date' in parsed_dates and 'end_date' in parsed_dates:
+            if parsed_dates['start_date'] >= parsed_dates['end_date']:
+                self._errors.append(
+                    f"'start_date' ({parsed_dates['start_date']}) must precede "
+                    f"'end_date' ({parsed_dates['end_date']})"
+                )
+
+    def _validate_paths(self, skip_fields: Set[str]) -> None:
+        """Check that required paths exist on disk.
+
+        Skips any field in skip_fields (already flagged as missing).
+        Checks cbh_dir only when output_cbh is true.
+        """
+        from pathlib import Path
+
+        # Check paramdb_dir exists as a directory
+        if 'paramdb_dir' not in skip_fields:
+            paramdb_dir = self._config.get_value('paramdb_dir')
+            if not Path(paramdb_dir).is_dir():
+                self._errors.append(
+                    f"Path for 'paramdb_dir' does not exist: {paramdb_dir}"
+                )
+
+        # Check control_filename exists as a file
+        if 'control_filename' not in skip_fields:
+            control_filename = self._config.get_value('control_filename')
+            if not Path(control_filename).is_file():
+                self._errors.append(
+                    f"Path for 'control_filename' does not exist: {control_filename}"
+                )
+
+        # Check cbh_dir exists on disk when output_cbh is true
+        if self._config.get_value('output_cbh') and 'cbh_dir' not in skip_fields:
+            cbh_dir = self._config.get_value('cbh_dir')
+            if not Path(cbh_dir).exists():
+                self._errors.append(
+                    f"Path for 'cbh_dir' does not exist: {cbh_dir}"
+                )
+
+    def _validate_cbh_fields(self) -> None:
+        """When output_cbh is true, check cbh_dir and cbh_var_map."""
+        if not self._config.get_value('output_cbh'):
+            return
+
+        # Check cbh_dir is present and non-empty
+        if not self._config.exists('cbh_dir') or self._config.is_empty('cbh_dir'):
+            self._errors.append(
+                "Field 'cbh_dir' is required when 'output_cbh' is enabled"
+            )
+
+        # Check cbh_var_map is a non-empty dictionary
+        cbh_var_map = self._config.get_value('cbh_var_map')
+        if not isinstance(cbh_var_map, dict) or len(cbh_var_map) == 0:
+            self._errors.append(
+                "Field 'cbh_var_map' must be a non-empty dictionary when 'output_cbh' is enabled"
+            )
+
+    def _validate_model_output_fields(self) -> None:
+        """When include_model_output is true, check output_vars_dir and output_vars."""
+        if not self._config.get_value('include_model_output'):
+            return
+
+        # Check output_vars_dir is a non-empty string
+        if not self._config.exists('output_vars_dir') or self._config.is_empty('output_vars_dir'):
+            self._errors.append(
+                "Field 'output_vars_dir' is required when 'include_model_output' is enabled"
+            )
+
+        # Check output_vars is a non-empty list
+        if not self._config.exists('output_vars') or self._config.is_empty('output_vars'):
+            self._errors.append(
+                "Field 'output_vars' is required when 'include_model_output' is enabled"
+            )
+
+    def _validate_streamflow_fields(self) -> None:
+        """When output_streamflow is true, check streamflow_filename."""
+        if not self._config.get_value('output_streamflow'):
+            return
+
+        # Check streamflow_filename is a non-empty string
+        if not self._config.exists('streamflow_filename') or self._config.is_empty('streamflow_filename'):
+            self._errors.append(
+                "Field 'streamflow_filename' is required when 'output_streamflow' is enabled"
+            )
+
+    def _validate_gis_fields(self) -> None:
+        """When output_shapefiles is true, check gis structure."""
+        if not self._config.get_value('output_shapefiles'):
+            return
+
+        # Check gis is a non-empty dictionary
+        gis = self._config.get_value('gis')
+        if not isinstance(gis, dict) or len(gis) == 0:
+            self._errors.append(
+                "Field 'gis' must be a non-empty dictionary when 'output_shapefiles' is enabled"
+            )
+            return
+
+        # Check gis contains required keys
+        required_keys = ['src_filename', 'dst_extension', 'layers']
+        for key in required_keys:
+            if key not in gis:
+                self._errors.append(
+                    f"GIS config is missing required key '{key}'"
+                )
+
+        # Check gis['src_filename'] is a non-empty string
+        if 'src_filename' in gis:
+            src = gis['src_filename']
+            if not isinstance(src, str) or len(src.strip()) == 0:
+                self._errors.append(
+                    "GIS config 'src_filename' is missing or empty"
+                )
+
+        # Check gis['layers'] is a non-empty dictionary
+        if 'layers' in gis:
+            layers = gis['layers']
+            if not isinstance(layers, dict) or len(layers) == 0:
+                self._errors.append(
+                    "GIS config 'layers' must be a non-empty dictionary"
+                )
+
+    def _validate_list_types(self) -> None:
+        """Check that outlets, cutoffs, hru_noroute contain only integers."""
+        import numpy as np
+
+        for name in ('outlets', 'cutoffs', 'hru_noroute'):
+            if not self._config.exists(name) or self._config.is_empty(name):
+                continue
+
+            values = self._config.get_value(name)
+            if not isinstance(values, list):
+                continue
+
+            for elem in values:
+                if not isinstance(elem, (int, np.integer)):
+                    self._errors.append(
+                        f"Field '{name}' contains non-integer element: {elem}"
+                    )

--- a/Bandit/points_of_interest.py
+++ b/Bandit/points_of_interest.py
@@ -125,6 +125,7 @@ class POI:
             # print('\t\tOpen dataset')
             self.__outdata = xr.open_mfdataset(self.__src_path,
                                                chunks={}, combine='nested',
+                                               join='outer',
                                                # chunks={'poi_id': 1040}, combine='nested',
                                                concat_dim='poi_id', decode_cf=True,
                                                engine='netcdf4')

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,0 +1,775 @@
+"""Tests for ConfigValidator."""
+
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from Bandit.config_validator import ConfigValidator
+
+
+def _make_config(**overrides):
+    """Create a mock Cfg with sensible defaults, overridden by kwargs.
+
+    All core fields are valid by default so tests can focus on the
+    specific behaviour under test.
+    """
+    defaults = {
+        'output_dir': '/tmp/output',
+        'param_filename': 'myparam.param',
+        'paramdb_dir': '/tmp/paramdb',
+        'control_filename': 'control.default',
+        'start_date': '1980-01-01',
+        'end_date': '2010-12-31',
+        'outlets': [],
+        'cutoffs': [],
+        'hru_noroute': [],
+        'output_cbh': False,
+        'cbh_dir': '',
+        'cbh_var_map': {},
+        'include_model_output': False,
+        'output_vars_dir': '',
+        'output_vars': [],
+        'output_streamflow': False,
+        'streamflow_filename': 'sf_data',
+        'output_shapefiles': False,
+        'gis': {},
+    }
+    defaults.update(overrides)
+
+    cfg = MagicMock()
+    cfg.exists.side_effect = lambda name: name in defaults
+    cfg.is_empty.side_effect = lambda name: (
+        defaults[name] == '' or defaults[name] == [] or defaults[name] == {}
+        if isinstance(defaults[name], (str, list, dict)) else False
+    )
+    cfg.get_value.side_effect = lambda name: defaults[name]
+    return cfg
+
+
+class TestValidateDates:
+    """Tests for _validate_dates method."""
+
+    def test_valid_dates_no_errors(self):
+        cfg = _make_config(start_date='2000-01-01', end_date='2010-12-31')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        date_errors = [e for e in errors if 'date' in e.lower()]
+        assert date_errors == []
+
+    def test_invalid_start_date_format(self):
+        cfg = _make_config(start_date='not-a-date', end_date='2010-12-31')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        assert any("Field 'start_date' has invalid date format 'not-a-date'" in e for e in errors)
+
+    def test_invalid_end_date_format(self):
+        cfg = _make_config(start_date='2000-01-01', end_date='31-12-2010')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        assert any("Field 'end_date' has invalid date format '31-12-2010'" in e for e in errors)
+
+    def test_start_date_equals_end_date(self):
+        cfg = _make_config(start_date='2010-06-15', end_date='2010-06-15')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        assert any("'start_date'" in e and "must precede" in e for e in errors)
+
+    def test_start_date_after_end_date(self):
+        cfg = _make_config(start_date='2020-01-01', end_date='2010-01-01')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        assert any("'start_date' (2020-01-01) must precede 'end_date' (2010-01-01)" in e for e in errors)
+
+    def test_datetime_date_objects_accepted(self):
+        """ruamel.yaml may parse bare dates as datetime.date objects."""
+        cfg = _make_config(
+            start_date=datetime.date(2000, 1, 1),
+            end_date=datetime.date(2010, 12, 31),
+        )
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        date_errors = [e for e in errors if 'date' in e.lower()]
+        assert date_errors == []
+
+    def test_datetime_date_ordering_check(self):
+        """datetime.date objects should also be checked for ordering."""
+        cfg = _make_config(
+            start_date=datetime.date(2020, 1, 1),
+            end_date=datetime.date(2010, 1, 1),
+        )
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        assert any("must precede" in e for e in errors)
+
+    def test_empty_dates_skipped(self):
+        """Empty date fields are caught by core validation, not date validation."""
+        cfg = _make_config(start_date='', end_date='')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        # Should have "missing or empty" errors but no date format errors
+        format_errors = [e for e in errors if 'invalid date format' in e]
+        assert format_errors == []
+
+    def test_both_dates_invalid_format(self):
+        cfg = _make_config(start_date='abc', end_date='xyz')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        format_errors = [e for e in errors if 'invalid date format' in e]
+        assert len(format_errors) == 2
+
+    def test_only_start_invalid_no_ordering_check(self):
+        """If start_date is unparseable, ordering check should be skipped."""
+        cfg = _make_config(start_date='bad', end_date='2010-12-31')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        assert any("invalid date format" in e for e in errors)
+        assert not any("must precede" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests (Hypothesis)
+# ---------------------------------------------------------------------------
+from hypothesis import given, settings, assume, HealthCheck
+from hypothesis import strategies as st
+
+
+# Feature: config-validation, Property 1: Core field presence detection
+class TestPropertyCoreFieldPresence:
+    """Property 1: For any subset of core fields that are missing or empty,
+    the validator SHALL return an error for each such field, and the error
+    message SHALL contain the field name.
+
+    **Validates: Requirements 1.1, 1.2, 1.3**
+    """
+
+    CORE_FIELDS = [
+        'output_dir', 'param_filename', 'paramdb_dir',
+        'control_filename', 'start_date', 'end_date',
+    ]
+
+    @given(
+        omit_fields=st.lists(
+            st.sampled_from([
+                'output_dir', 'param_filename', 'paramdb_dir',
+                'control_filename', 'start_date', 'end_date',
+            ]),
+            unique=True,
+            min_size=0,
+            max_size=6,
+        ),
+        use_empty=st.booleans(),
+    )
+    @settings(max_examples=100)
+    def test_core_field_presence(self, omit_fields, use_empty):
+        """Each omitted or emptied core field produces an error containing its name."""
+        overrides = {}
+        for field in omit_fields:
+            if use_empty:
+                # Set to empty string (is_empty returns True for '')
+                overrides[field] = ''
+            else:
+                # Set to empty string as well — the mock's exists still returns True
+                # but is_empty returns True for ''
+                overrides[field] = ''
+
+        cfg = _make_config(**overrides)
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        # Filter to only "missing or empty" errors
+        missing_errors = [e for e in errors if 'missing or empty' in e]
+
+        # Each omitted field should produce exactly one error containing its name
+        for field in omit_fields:
+            matching = [e for e in missing_errors if field in e]
+            assert len(matching) == 1, (
+                f"Expected exactly 1 'missing or empty' error for '{field}', "
+                f"got {len(matching)}: {matching}"
+            )
+
+        # Fields NOT in omit_fields should NOT produce missing errors
+        for field in self.CORE_FIELDS:
+            if field not in omit_fields:
+                matching = [e for e in missing_errors if field in e]
+                assert len(matching) == 0, (
+                    f"Unexpected 'missing or empty' error for '{field}': {matching}"
+                )
+
+
+# Feature: config-validation, Property 2: Date format validation
+class TestPropertyDateFormatValidation:
+    """Property 2: For any string value assigned to start_date or end_date,
+    the validator SHALL produce a date-format error if and only if the string
+    is not parseable as a valid YYYY-MM-DD date.
+
+    **Validates: Requirements 3.1, 3.2, 3.3**
+    """
+
+    @staticmethod
+    def _is_valid_date_str(s):
+        """Check if a string is a valid YYYY-MM-DD date."""
+        try:
+            datetime.datetime.strptime(s, '%Y-%m-%d')
+            return True
+        except (ValueError, TypeError):
+            return False
+
+    # Strategy: valid YYYY-MM-DD date strings
+    valid_date_st = st.dates(
+        min_value=datetime.date(1900, 1, 1),
+        max_value=datetime.date(2100, 12, 31),
+    ).map(lambda d: d.strftime('%Y-%m-%d'))
+
+    # Strategy: invalid date strings (not parseable as YYYY-MM-DD)
+    invalid_date_st = st.one_of(
+        st.text(min_size=1, max_size=20).filter(
+            lambda s: not __class__._is_valid_date_str(s) and s.strip() != ''
+        ),
+        st.just('2024-13-01'),   # invalid month
+        st.just('2024-02-30'),   # invalid day
+        st.just('01-01-2024'),   # wrong format
+        st.just('not-a-date'),
+    )
+
+    # Strategy: datetime.date objects (YAML type coercion)
+    date_object_st = st.dates(
+        min_value=datetime.date(1900, 1, 1),
+        max_value=datetime.date(2100, 12, 31),
+    )
+
+    # Combined strategy for date values
+    date_value_st = st.one_of(valid_date_st, invalid_date_st, date_object_st)
+
+    @given(date_value=st.one_of(
+        st.dates(
+            min_value=datetime.date(1900, 1, 1),
+            max_value=datetime.date(2100, 12, 31),
+        ).map(lambda d: d.strftime('%Y-%m-%d')),
+        st.one_of(
+            st.text(min_size=1, max_size=20),
+            st.just('2024-13-01'),
+            st.just('2024-02-30'),
+            st.just('01-01-2024'),
+            st.just('not-a-date'),
+        ),
+        st.dates(
+            min_value=datetime.date(1900, 1, 1),
+            max_value=datetime.date(2100, 12, 31),
+        ),
+    ))
+    @settings(max_examples=100)
+    def test_date_format_validation(self, date_value):
+        """Error iff date value is not parseable as YYYY-MM-DD (or a datetime.date)."""
+        # Skip empty strings — those are caught by core field validation, not date format
+        if isinstance(date_value, str) and date_value.strip() == '':
+            assume(False)
+
+        # Use a valid end_date far in the future so we only test start_date format
+        cfg = _make_config(start_date=date_value, end_date='2099-12-31')
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        format_errors = [e for e in errors if "invalid date format" in e and "start_date" in e]
+
+        if isinstance(date_value, datetime.date):
+            # datetime.date objects are always valid
+            assert len(format_errors) == 0, (
+                f"datetime.date {date_value} should not produce format error: {format_errors}"
+            )
+        elif isinstance(date_value, str) and self._is_valid_date_str(date_value):
+            assert len(format_errors) == 0, (
+                f"Valid date string '{date_value}' should not produce format error: {format_errors}"
+            )
+        else:
+            assert len(format_errors) == 1, (
+                f"Invalid date value '{date_value}' should produce exactly 1 format error, "
+                f"got {len(format_errors)}: {format_errors}"
+            )
+            assert str(date_value) in format_errors[0]
+
+
+# Feature: config-validation, Property 3: Date ordering
+class TestPropertyDateOrdering:
+    """Property 3: For any two valid YYYY-MM-DD date strings, the validator
+    SHALL produce a date-ordering error if and only if start_date >= end_date.
+
+    **Validates: Requirements 3.4**
+    """
+
+    @given(
+        start=st.dates(
+            min_value=datetime.date(1900, 1, 1),
+            max_value=datetime.date(2100, 12, 31),
+        ),
+        end=st.dates(
+            min_value=datetime.date(1900, 1, 1),
+            max_value=datetime.date(2100, 12, 31),
+        ),
+    )
+    @settings(max_examples=100)
+    def test_date_ordering(self, start, end):
+        """Error iff start_date >= end_date."""
+        cfg = _make_config(
+            start_date=start.strftime('%Y-%m-%d'),
+            end_date=end.strftime('%Y-%m-%d'),
+        )
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        ordering_errors = [e for e in errors if 'must precede' in e]
+
+        if start >= end:
+            assert len(ordering_errors) == 1, (
+                f"start={start}, end={end}: expected ordering error, got {ordering_errors}"
+            )
+            assert str(start) in ordering_errors[0]
+            assert str(end) in ordering_errors[0]
+        else:
+            assert len(ordering_errors) == 0, (
+                f"start={start}, end={end}: unexpected ordering error: {ordering_errors}"
+            )
+
+
+# Feature: config-validation, Property 4: Conditional field validation
+class TestPropertyConditionalFieldValidation:
+    """Property 4: For any conditional toggle and its associated required fields,
+    the validator SHALL produce an error for a field if and only if the toggle
+    is true and the field is missing or empty.
+
+    **Validates: Requirements 4.1, 4.2, 4.3, 4.4, 5.1, 5.2, 5.3, 5.4, 6.1, 6.2**
+    """
+
+    # Mapping of toggles to their required fields
+    TOGGLE_FIELDS = {
+        'output_cbh': ['cbh_dir', 'cbh_var_map'],
+        'include_model_output': ['output_vars_dir', 'output_vars'],
+        'output_streamflow': ['streamflow_filename'],
+    }
+
+    # Non-empty values for each conditional field
+    NON_EMPTY_VALUES = {
+        'cbh_dir': '/tmp/cbh',
+        'cbh_var_map': {'tmax': 'tmax.cbh', 'tmin': 'tmin.cbh'},
+        'output_vars_dir': '/tmp/output_vars',
+        'output_vars': ['seg_outflow'],
+        'streamflow_filename': 'sf_data',
+    }
+
+    # Empty values for each conditional field
+    EMPTY_VALUES = {
+        'cbh_dir': '',
+        'cbh_var_map': {},
+        'output_vars_dir': '',
+        'output_vars': [],
+        'streamflow_filename': '',
+    }
+
+    @given(
+        toggle_states=st.fixed_dictionaries({
+            'output_cbh': st.booleans(),
+            'include_model_output': st.booleans(),
+            'output_streamflow': st.booleans(),
+        }),
+        empty_fields=st.lists(
+            st.sampled_from([
+                'cbh_dir', 'cbh_var_map', 'output_vars_dir',
+                'output_vars', 'streamflow_filename',
+            ]),
+            unique=True,
+            min_size=0,
+            max_size=5,
+        ),
+    )
+    @settings(max_examples=100)
+    def test_conditional_field_validation(self, toggle_states, empty_fields):
+        """Error iff toggle is true and associated field is empty."""
+        overrides = dict(toggle_states)
+
+        # Set field values: empty or non-empty
+        for field in self.NON_EMPTY_VALUES:
+            if field in empty_fields:
+                overrides[field] = self.EMPTY_VALUES[field]
+            else:
+                overrides[field] = self.NON_EMPTY_VALUES[field]
+
+        cfg = _make_config(**overrides)
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        # Check each toggle/field combination
+        for toggle, fields in self.TOGGLE_FIELDS.items():
+            for field in fields:
+                # Find errors mentioning this field and its toggle
+                field_errors = [
+                    e for e in errors
+                    if field in e and toggle.replace('_', '') in e.replace('_', '')
+                    or (field in e and 'required when' in e)
+                    or (field in e and 'non-empty dictionary when' in e)
+                ]
+
+                should_error = toggle_states[toggle] and field in empty_fields
+
+                if should_error:
+                    assert len(field_errors) >= 1, (
+                        f"toggle={toggle}=True, field={field} empty: "
+                        f"expected error, got none. All errors: {errors}"
+                    )
+                elif not toggle_states[toggle]:
+                    # When toggle is off, no error for this field from conditional checks
+                    conditional_errors = [
+                        e for e in errors
+                        if field in e and ('required when' in e or 'non-empty dictionary when' in e)
+                    ]
+                    assert len(conditional_errors) == 0, (
+                        f"toggle={toggle}=False: unexpected conditional error for "
+                        f"'{field}': {conditional_errors}"
+                    )
+
+
+# Feature: config-validation, Property 5: GIS structure validation
+class TestPropertyGISStructureValidation:
+    """Property 5: For any configuration where output_shapefiles is true,
+    the validator SHALL produce an error if gis is not a non-empty dictionary,
+    or if gis is missing any of the required keys.
+
+    **Validates: Requirements 7.1, 7.2, 7.3, 7.4, 7.5**
+    """
+
+    REQUIRED_KEYS = ['src_filename', 'dst_extension', 'layers']
+
+    @given(
+        shapefiles_enabled=st.booleans(),
+        present_keys=st.lists(
+            st.sampled_from(['src_filename', 'dst_extension', 'layers']),
+            unique=True,
+            min_size=0,
+            max_size=3,
+        ),
+        src_empty=st.booleans(),
+        layers_empty=st.booleans(),
+    )
+    @settings(max_examples=100)
+    def test_gis_structure_validation(self, shapefiles_enabled, present_keys,
+                                      src_empty, layers_empty):
+        """Errors match missing/empty keys when output_shapefiles is true."""
+        if shapefiles_enabled and len(present_keys) > 0:
+            # Build a gis dict with only the present keys
+            gis = {}
+            for key in present_keys:
+                if key == 'src_filename':
+                    gis[key] = '' if src_empty else 'source.shp'
+                elif key == 'layers':
+                    gis[key] = {} if layers_empty else {'nhru': 'nhru_layer'}
+                elif key == 'dst_extension':
+                    gis[key] = '.shp'
+        elif shapefiles_enabled:
+            # Empty dict
+            gis = {}
+        else:
+            gis = {}
+
+        cfg = _make_config(output_shapefiles=shapefiles_enabled, gis=gis)
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        gis_errors = [e for e in errors if 'gis' in e.lower() or 'GIS' in e]
+
+        if not shapefiles_enabled:
+            # No GIS errors when shapefiles disabled
+            assert len(gis_errors) == 0, (
+                f"Shapefiles disabled but got GIS errors: {gis_errors}"
+            )
+        elif len(present_keys) == 0:
+            # Empty gis dict → "must be a non-empty dictionary" error
+            assert any('non-empty dictionary' in e for e in gis_errors), (
+                f"Empty gis dict should produce 'non-empty dictionary' error: {gis_errors}"
+            )
+        else:
+            # Check missing keys produce errors
+            for key in self.REQUIRED_KEYS:
+                missing_key_errors = [e for e in gis_errors if f"'{key}'" in e]
+                if key not in present_keys:
+                    assert len(missing_key_errors) >= 1, (
+                        f"Missing key '{key}' should produce error: {gis_errors}"
+                    )
+
+            # Check src_filename empty produces error
+            if 'src_filename' in present_keys and src_empty:
+                src_errors = [e for e in gis_errors if 'src_filename' in e and ('empty' in e or 'missing' in e)]
+                assert len(src_errors) >= 1, (
+                    f"Empty src_filename should produce error: {gis_errors}"
+                )
+
+            # Check layers empty produces error
+            if 'layers' in present_keys and layers_empty:
+                layers_errors = [e for e in gis_errors if 'layers' in e and 'non-empty dictionary' in e]
+                assert len(layers_errors) >= 1, (
+                    f"Empty layers should produce error: {gis_errors}"
+                )
+
+
+# Feature: config-validation, Property 6: List element type validation
+class TestPropertyListElementTypeValidation:
+    """Property 6: For any of the list fields that contain at least one element,
+    the validator SHALL produce an error for each non-integer element.
+
+    **Validates: Requirements 8.1, 8.2, 8.3, 8.4**
+    """
+
+    # Strategy for list elements: mix of ints and non-ints
+    int_element = st.integers(min_value=-10000, max_value=10000)
+    non_int_element = st.one_of(
+        st.text(min_size=1, max_size=10),
+        st.floats(allow_nan=False, allow_infinity=False),
+        st.just(None),
+        st.just(True),
+    )
+    mixed_element = st.one_of(int_element, non_int_element)
+
+    @given(
+        field_name=st.sampled_from(['outlets', 'cutoffs', 'hru_noroute']),
+        elements=st.lists(
+            st.one_of(
+                st.integers(min_value=-10000, max_value=10000),
+                st.text(min_size=1, max_size=10),
+                st.floats(allow_nan=False, allow_infinity=False),
+                st.just(None),
+            ),
+            min_size=1,
+            max_size=10,
+        ),
+    )
+    @settings(max_examples=100)
+    def test_list_element_types(self, field_name, elements):
+        """Error for each non-integer element in list fields."""
+        import numpy as np
+
+        cfg = _make_config(**{field_name: elements})
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        type_errors = [e for e in errors if 'non-integer element' in e and field_name in e]
+
+        # Count expected non-integer elements (booleans are excluded from int check
+        # by the isinstance check in the validator since bool is subclass of int,
+        # but the validator uses isinstance(elem, (int, np.integer)) which includes bool)
+        expected_non_ints = [
+            elem for elem in elements
+            if not isinstance(elem, (int, np.integer))
+        ]
+
+        assert len(type_errors) == len(expected_non_ints), (
+            f"Field '{field_name}', elements={elements}: "
+            f"expected {len(expected_non_ints)} type errors, got {len(type_errors)}. "
+            f"Errors: {type_errors}"
+        )
+
+        # Each non-integer element should be mentioned in an error
+        for elem in expected_non_ints:
+            matching = [e for e in type_errors if str(elem) in e]
+            assert len(matching) >= 1, (
+                f"Non-integer element {elem!r} should appear in an error: {type_errors}"
+            )
+
+
+# Feature: config-validation, Property 7: Path existence validation
+class TestPropertyPathExistenceValidation:
+    """Property 7: For any configuration where path fields are non-empty,
+    the validator SHALL produce an error if the path does not exist on disk.
+    When a path field was already flagged as missing/empty, no path-existence
+    error SHALL be produced for it.
+
+    **Validates: Requirements 2.1, 2.2, 2.3, 2.4**
+    """
+
+    @given(
+        paramdb_exists=st.booleans(),
+        control_exists=st.booleans(),
+        cbh_enabled=st.booleans(),
+        cbh_exists=st.booleans(),
+    )
+    @settings(max_examples=100, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_path_existence_validation(self, tmp_path, paramdb_exists,
+                                       control_exists, cbh_enabled, cbh_exists):
+        """Error iff path doesn't exist on disk and field was not flagged as missing."""
+        import tempfile
+        # Use a unique temp directory per hypothesis example to avoid state leakage
+        run_dir = tempfile.mkdtemp(dir=tmp_path)
+        from pathlib import Path
+        run_path = Path(run_dir)
+
+        paramdb_dir = str(run_path / 'paramdb')
+        control_file = str(run_path / 'control.default')
+        cbh_dir = str(run_path / 'cbh')
+
+        if paramdb_exists:
+            (run_path / 'paramdb').mkdir(exist_ok=True)
+        if control_exists:
+            (run_path / 'control.default').touch()
+        if cbh_exists:
+            (run_path / 'cbh').mkdir(exist_ok=True)
+
+        overrides = {
+            'paramdb_dir': paramdb_dir,
+            'control_filename': control_file,
+            'output_cbh': cbh_enabled,
+            'cbh_dir': cbh_dir if cbh_enabled else '',
+        }
+
+        # If cbh is enabled, provide a non-empty cbh_var_map to avoid conditional errors
+        if cbh_enabled:
+            overrides['cbh_var_map'] = {'tmax': 'tmax.cbh'}
+
+        cfg = _make_config(**overrides)
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        path_errors = [e for e in errors if 'does not exist' in e]
+
+        # Check paramdb_dir
+        paramdb_path_errors = [e for e in path_errors if 'paramdb_dir' in e]
+        if paramdb_exists:
+            assert len(paramdb_path_errors) == 0, (
+                f"paramdb_dir exists but got error: {paramdb_path_errors}"
+            )
+        else:
+            assert len(paramdb_path_errors) == 1, (
+                f"paramdb_dir missing but no error: {path_errors}"
+            )
+
+        # Check control_filename
+        control_path_errors = [e for e in path_errors if 'control_filename' in e]
+        if control_exists:
+            assert len(control_path_errors) == 0, (
+                f"control_filename exists but got error: {control_path_errors}"
+            )
+        else:
+            assert len(control_path_errors) == 1, (
+                f"control_filename missing but no error: {path_errors}"
+            )
+
+        # Check cbh_dir (only when enabled)
+        cbh_path_errors = [e for e in path_errors if 'cbh_dir' in e]
+        if cbh_enabled:
+            if cbh_exists:
+                assert len(cbh_path_errors) == 0, (
+                    f"cbh_dir exists but got error: {cbh_path_errors}"
+                )
+            else:
+                assert len(cbh_path_errors) == 1, (
+                    f"cbh_dir missing but no error: {path_errors}"
+                )
+        else:
+            assert len(cbh_path_errors) == 0, (
+                f"cbh disabled but got cbh_dir path error: {cbh_path_errors}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for integration and edge cases (Task 6.1)
+# ---------------------------------------------------------------------------
+class TestConfigValidatorUnit:
+    """Unit tests for ConfigValidator edge cases and integration.
+
+    **Validates: Requirements 10.1, 3.1, 3.2**
+    """
+
+    def test_fully_valid_config_no_errors(self, tmp_path):
+        """A fully valid config with existing paths returns an empty error list."""
+        # Create real paths
+        paramdb = tmp_path / 'paramdb'
+        paramdb.mkdir()
+        control = tmp_path / 'control.default'
+        control.touch()
+
+        cfg = _make_config(
+            output_dir=str(tmp_path / 'output'),
+            param_filename='myparam.param',
+            paramdb_dir=str(paramdb),
+            control_filename=str(control),
+            start_date='2000-01-01',
+            end_date='2010-12-31',
+        )
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        assert errors == [], f"Expected no errors for valid config, got: {errors}"
+
+    def test_datetime_date_objects_handled_correctly(self, tmp_path):
+        """YAML type coercion: datetime.date objects are handled without errors."""
+        paramdb = tmp_path / 'paramdb'
+        paramdb.mkdir()
+        control = tmp_path / 'control.default'
+        control.touch()
+
+        cfg = _make_config(
+            paramdb_dir=str(paramdb),
+            control_filename=str(control),
+            start_date=datetime.date(2000, 1, 1),
+            end_date=datetime.date(2010, 12, 31),
+        )
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+        date_errors = [e for e in errors if 'date' in e.lower()]
+        assert date_errors == [], f"datetime.date objects should not produce date errors: {date_errors}"
+
+    def test_multiple_errors_across_categories_collected(self):
+        """Multiple errors across different categories are all collected in a single pass."""
+        cfg = _make_config(
+            output_dir='',                          # core field error
+            start_date='not-a-date',                # date format error
+            output_cbh=True,                        # conditional toggle
+            cbh_dir='',                             # conditional field error
+            cbh_var_map={},                         # conditional field error
+            outlets=[1, 'bad', 2],                  # list type error
+        )
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        # Should have errors from multiple categories
+        has_core_error = any('missing or empty' in e and 'output_dir' in e for e in errors)
+        has_date_error = any('invalid date format' in e for e in errors)
+        has_conditional_error = any('required when' in e or 'non-empty dictionary when' in e for e in errors)
+        has_list_error = any('non-integer element' in e for e in errors)
+
+        assert has_core_error, f"Expected core field error in: {errors}"
+        assert has_date_error, f"Expected date format error in: {errors}"
+        assert has_conditional_error, f"Expected conditional field error in: {errors}"
+        assert has_list_error, f"Expected list type error in: {errors}"
+
+    def test_error_count_matches_expected_failures(self, tmp_path):
+        """Error count matches the expected number of individual failures."""
+        paramdb = tmp_path / 'paramdb'
+        paramdb.mkdir()
+        control = tmp_path / 'control.default'
+        control.touch()
+
+        # Create config with exactly 3 known errors:
+        # 1. output_dir empty → "Required field 'output_dir' is missing or empty"
+        # 2. start_date invalid → "Field 'start_date' has invalid date format..."
+        # 3. outlets has non-int → "Field 'outlets' contains non-integer element: bad"
+        cfg = _make_config(
+            output_dir='',
+            paramdb_dir=str(paramdb),
+            control_filename=str(control),
+            start_date='invalid',
+            end_date='2010-12-31',
+            outlets=[1, 'bad'],
+        )
+        v = ConfigValidator(cfg)
+        errors = v.validate()
+
+        # Count specific expected errors
+        core_errors = [e for e in errors if "Required field 'output_dir' is missing or empty" in e]
+        date_errors = [e for e in errors if "invalid date format" in e and "start_date" in e]
+        list_errors = [e for e in errors if "non-integer element" in e and "outlets" in e]
+
+        assert len(core_errors) == 1, f"Expected 1 core error, got: {core_errors}"
+        assert len(date_errors) == 1, f"Expected 1 date error, got: {date_errors}"
+        assert len(list_errors) == 1, f"Expected 1 list error, got: {list_errors}"
+
+        # Total should be exactly 3
+        expected_count = 3
+        assert len(errors) == expected_count, (
+            f"Expected exactly {expected_count} errors, got {len(errors)}: {errors}"
+        )


### PR DESCRIPTION
## Summary

Updates to the subsetting workflow, helper refactoring, and minor fixes across the Bandit extraction pipeline.

## Changes

- **Cfg.is_empty**: Handle `datetime.date` instances so YAML-parsed bare dates are not incorrectly reported as empty
- **bandit_helpers**: Rename loop variables for readability, remove unused `new_nhm_seg` parameter from `get_output_order` and `get_poi_subset`, extract `_renumber_hru_segments` into a standalone helper, replace dense list comprehension with explicit loop
- **points_of_interest**: Add `join='outer'` to `xr.open_mfdataset` to prevent data loss when POI netCDF files have non-identical `poi_id` coordinates