### PR TITLE
Standardize logging output in extract()

### DIFF
--- a/.kiro/specs/standardize-logging/.config.kiro
+++ b/.kiro/specs/standardize-logging/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "c8b74f36-c151-45e9-a506-1fa557c8546c", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/standardize-logging/design.md
+++ b/.kiro/specs/standardize-logging/design.md
@@ -1,0 +1,199 @@
+# Design Document: Standardize Logging
+
+## Overview
+
+This feature standardizes all output in `Bandit/bandit.py` by replacing bare `print()` calls and direct `sys.stdout.write()`/`sys.stdout.flush()` calls with the two established output channels:
+
+- **Rich console (`con.print()`)** for user-facing messages with markup
+- **Python logger (`bandit_log`)** for persistent log records
+
+The refactoring is localized to the `extract()` function in a single file. No new modules, classes, or functions are introduced. The existing `con` and `bandit_log` instances are already initialized at module level and used extensively throughout the file — this change simply makes their usage consistent by eliminating the five remaining non-standard output calls.
+
+### Design Decisions
+
+1. **No new abstractions**: The file already has `con` and `bandit_log` set up correctly. The fix is mechanical — replace each non-standard call with the appropriate existing channel. Adding a wrapper or helper would over-engineer a simple refactoring.
+
+2. **Dual-channel for errors and warnings**: Error messages go to both `con.print()` (for immediate user visibility with red markup) and `bandit_log.error()` (for log file persistence). This matches the pattern already established in the config validation block (lines 131–136).
+
+3. **Rich Rule for separators**: The bare `print('-'*40)` separator is replaced with `con.print(Rule())` from the Rich library, which produces a styled horizontal rule that respects console width and theming.
+
+4. **Remove `sys` import**: After eliminating `sys.stdout.write()` and `sys.stdout.flush()`, the `sys` module has no remaining references in the file. The import is removed to keep dependencies accurate.
+
+## Architecture
+
+The architecture is unchanged. The refactoring only modifies how five specific lines produce output, routing them through the existing `con` and `bandit_log` channels.
+
+```mermaid
+flowchart LR
+    subgraph Before
+        A1[print] --> OUT1[stdout]
+        A2[sys.stdout.write] --> OUT1
+        A3[sys.stdout.flush] --> OUT1
+        A4[con.print] --> OUT2[Rich console]
+        A5[bandit_log] --> OUT3[Log file]
+    end
+
+    subgraph After
+        B1[con.print] --> OUT4[Rich console]
+        B2[bandit_log] --> OUT5[Log file]
+    end
+```
+
+All output flows through exactly two channels after the refactoring.
+
+## Components and Interfaces
+
+No new components or interfaces are introduced. The changes are limited to five call sites in the `extract()` function within `Bandit/bandit.py`.
+
+### Change Inventory
+
+Each change below identifies the exact current code and its replacement.
+
+#### Change 1: Invalid job directory error (line ~118)
+
+**Current:**
+```python
+print(f'ERROR: Invalid jobs directory: {str(job_dir)}')
+```
+
+**Replacement:**
+```python
+con.print(f'[red]ERROR[/]: Invalid jobs directory: {str(job_dir)}')
+bandit_log.error(f'Invalid jobs directory: {str(job_dir)}')
+```
+
+**Rationale:** This is an error condition. It should use dual-channel output: Rich console with red ERROR markup for the user, and logger at ERROR level for the log file. Matches the pattern used in the config validation block.
+
+#### Change 2: Blank line after parameter file write (lines ~323–324)
+
+**Current:**
+```python
+if verbose:
+    sys.stdout.write('\n')
+sys.stdout.flush()
+```
+
+**Replacement:**
+```python
+if verbose:
+    con.print('')
+```
+
+**Rationale:** The `sys.stdout.write('\n')` produces a blank line for visual spacing. `con.print('')` achieves the same effect through the Rich console. The unconditional `sys.stdout.flush()` is no longer needed — Rich handles its own flushing. The flush outside the `if verbose` block served no purpose when verbose was false (nothing was written), so the entire block collapses into a single conditional `con.print('')`.
+
+#### Change 3: Dynamic parameter verbose message (line ~419)
+
+**Current:**
+```python
+print(f'Writing dynamic parameter {cparam}')
+```
+
+**Replacement:**
+```python
+con.print(f'[green4]INFO[/]: Writing dynamic parameter {cparam}')
+```
+
+**Rationale:** This is a verbose informational message about a processing step. It follows the same `[green4]INFO[/]` pattern used by other verbose messages in the file (e.g., "Writing parameter file for PRMS ...").
+
+#### Change 4: Shapefile separator (line ~497)
+
+**Current:**
+```python
+print('-'*40)
+```
+
+**Replacement:**
+```python
+from rich.rule import Rule
+# (import added at top of file)
+con.print(Rule())
+```
+
+**Rationale:** The repeated-dash separator is replaced with a Rich `Rule()`, which renders a styled horizontal line that adapts to console width. This is the idiomatic Rich approach for visual separators.
+
+#### Change 5: Remove `sys` import (line ~7)
+
+**Current:**
+```python
+import sys
+```
+
+**Replacement:** Line removed entirely.
+
+**Rationale:** After changes 2, `sys` has no remaining references in the file. The `import` statement is removed to keep the module's imports accurate.
+
+#### Addition: Import `Rule` from Rich (top of file)
+
+**New import added:**
+```python
+from rich.rule import Rule
+```
+
+**Rationale:** Needed for Change 4 (the separator replacement).
+
+### Summary of Changes
+
+| # | Location | Current Code | New Code | Channel |
+|---|---|---|---|---|
+| 1 | ~line 118 | `print(f'ERROR: ...')` | `con.print(f'[red]ERROR[/]: ...')` + `bandit_log.error(...)` | Dual |
+| 2 | ~lines 323–324 | `sys.stdout.write('\n')` / `sys.stdout.flush()` | `con.print('')` | Console |
+| 3 | ~line 419 | `print(f'Writing dynamic parameter ...')` | `con.print(f'[green4]INFO[/]: ...')` | Console |
+| 4 | ~line 497 | `print('-'*40)` | `con.print(Rule())` | Console |
+| 5 | line 7 | `import sys` | *(removed)* | — |
+| 6 | imports | — | `from rich.rule import Rule` | — |
+
+## Data Models
+
+No data models are introduced or modified. The refactoring changes only how existing string messages are routed to output channels.
+
+## Error Handling
+
+Error handling behavior is preserved. The only change is the output mechanism:
+
+- The invalid job directory error (Change 1) currently calls `print()` then `exit(-1)`. After the change, it calls `con.print()` and `bandit_log.error()` then `exit(-1)`. The exit behavior is unchanged.
+- No new error conditions are introduced.
+- No existing error handling paths are altered beyond their output method.
+
+## Testing Strategy
+
+### Why Property-Based Testing Does Not Apply
+
+This feature is a mechanical code refactoring — replacing five specific output calls with equivalent calls through different APIs. The changes are:
+
+- **Deterministic**: Each call site produces the same output regardless of input variation
+- **Not input-dependent**: The output channel choice doesn't vary with data
+- **Localized**: Five specific lines in one file, with no new logic or branching
+
+There are no universal properties that hold "for all inputs" — the correctness criterion is simply "these specific lines use these specific APIs." This is best verified through example-based tests and static analysis.
+
+### Test Approach
+
+**Static analysis tests** (AST inspection of `bandit.py`):
+
+| Test | Verifies |
+|---|---|
+| No bare `print()` calls in `extract` | Requirements 1.3, 2.2 |
+| No `sys.stdout.write()` calls | Requirement 3.1 |
+| No `sys.stdout.flush()` calls | Requirement 3.2 |
+| No `import sys` statement (or `sys` not referenced) | Requirement 6.1 |
+
+These tests parse the AST of `bandit.py` and walk the tree to verify the absence of prohibited call patterns. They are resilient to formatting changes and don't require mocking the full extraction pipeline.
+
+**Example-based unit tests** (with mocking):
+
+| Test | Verifies |
+|---|---|
+| Invalid job_dir triggers `con.print` with `[red]ERROR[/]` and `bandit_log.error` | Requirements 1.1, 1.2, 4.1 |
+| Verbose dynamic parameter message uses `con.print` with `[green4]INFO[/]` | Requirements 2.1, 4.3 |
+| Shapefile separator uses `con.print(Rule())` | Requirement 2.3 |
+| Verbose blank line uses `con.print('')` | Requirement 3.3 |
+| Existing `bandit_log` calls unchanged (spot check) | Requirement 5.1 |
+| Existing `con.print` calls unchanged (spot check) | Requirement 5.2 |
+
+**Test framework**: `pytest` (already in dev dependencies)
+
+**Test file location**: `tests/test_standardize_logging.py`
+
+### Preservation verification
+
+Requirements 5.1–5.3 (preserve existing patterns) are primarily verified through code review of the diff. The AST-based tests provide an automated safety net by confirming that no prohibited patterns exist, and the example-based tests confirm the new patterns are correct. Together, these ensure the refactoring is both complete (no old patterns remain) and correct (new patterns match expectations).

--- a/.kiro/specs/standardize-logging/requirements.md
+++ b/.kiro/specs/standardize-logging/requirements.md
@@ -1,0 +1,81 @@
+# Requirements Document
+
+## Introduction
+
+The `extract` function in `Bandit/bandit.py` currently uses a mix of four output methods: Python's `logging` module (`bandit_log`), Rich console (`con.print()`), bare `print()` statements, and direct `sys.stdout.write()`/`sys.stdout.flush()` calls. This inconsistency makes output behavior unpredictable across environments (e.g., piped output, log aggregation) and complicates maintenance.
+
+This feature standardizes all output in `bandit.py` on two channels:
+- **Rich console (`con`)** for user-facing status messages with markup
+- **Python logger (`bandit_log`)** for persistent log records
+
+Bare `print()` and `sys.stdout.write/flush` calls are eliminated entirely.
+
+## Glossary
+
+- **Bandit**: The model extraction application defined in `Bandit/bandit.py`
+- **Extract_Function**: The main `extract()` function that performs NHM parameter database subsetting
+- **Rich_Console**: The Rich library console instance (`con`) obtained from `get_console_instance()`
+- **Logger**: The Python logging instance (`bandit_log`) configured for the Bandit application
+- **User_Facing_Message**: A message intended to be seen by the operator running Bandit interactively
+- **Log_Record**: A message intended to be persisted in the log file for auditing or debugging
+
+## Requirements
+
+### Requirement 1: Replace bare print error messages with Rich console and logger
+
+**User Story:** As a developer, I want error messages to use the Rich console and logger consistently, so that errors are both visible to the user with proper formatting and recorded in the log file.
+
+#### Acceptance Criteria
+
+1. WHEN an error condition is detected, THE Extract_Function SHALL output the error message via Rich_Console using `[red]ERROR[/]` markup
+2. WHEN an error condition is detected, THE Extract_Function SHALL record the error message via Logger at the ERROR level
+3. THE Extract_Function SHALL NOT use bare `print()` calls to output error messages
+
+### Requirement 2: Replace bare print informational messages with Rich console
+
+**User Story:** As a developer, I want informational and verbose messages to use the Rich console, so that all user-facing output has consistent formatting and respects Rich console configuration.
+
+#### Acceptance Criteria
+
+1. WHEN verbose mode is active and a status update is generated, THE Extract_Function SHALL output the message via Rich_Console with appropriate styling
+2. THE Extract_Function SHALL NOT use bare `print()` calls to output informational or status messages
+3. WHEN a visual separator is needed, THE Extract_Function SHALL use Rich_Console with a Rule or styled separator instead of bare `print()` with repeated characters
+
+### Requirement 3: Eliminate sys.stdout.write and sys.stdout.flush calls
+
+**User Story:** As a developer, I want all direct stdout manipulation removed, so that output routing is fully controlled by the Rich console and logger abstractions.
+
+#### Acceptance Criteria
+
+1. THE Extract_Function SHALL NOT call `sys.stdout.write()` for any output purpose
+2. THE Extract_Function SHALL NOT call `sys.stdout.flush()` for any output purpose
+3. WHERE a blank line or spacing is needed between output sections, THE Extract_Function SHALL use `con.print()` with an empty string or appropriate Rich markup
+
+### Requirement 4: Dual-channel output for significant events
+
+**User Story:** As a developer, I want significant operational events (errors, warnings, key milestones) to appear in both the console and the log file, so that interactive users see immediate feedback and the log file retains a complete record.
+
+#### Acceptance Criteria
+
+1. WHEN an error occurs, THE Extract_Function SHALL output the message to both Rich_Console and Logger at ERROR level
+2. WHEN a warning condition is detected, THE Extract_Function SHALL output the message to both Rich_Console with `[gold3]WARNING[/]` markup and Logger at WARNING level
+3. WHEN a key processing milestone is reached, THE Extract_Function SHALL output the message to Rich_Console with `[green4]INFO[/]` markup and Logger at INFO level
+
+### Requirement 5: Preserve existing logger and Rich console patterns
+
+**User Story:** As a developer, I want the existing correct uses of `bandit_log` and `con.print()` to remain unchanged, so that the refactoring only addresses the inconsistent output methods without disrupting working code.
+
+#### Acceptance Criteria
+
+1. THE Extract_Function SHALL retain all existing `bandit_log` calls that currently use appropriate log levels
+2. THE Extract_Function SHALL retain all existing `con.print()` calls that currently use appropriate Rich markup
+3. THE Extract_Function SHALL NOT alter the log format, log level configuration, or Rich console instantiation
+
+### Requirement 6: Remove sys import dependency for output
+
+**User Story:** As a developer, I want the `sys` module import to be removed if it is no longer needed after eliminating stdout calls, so that the module's imports accurately reflect its dependencies.
+
+#### Acceptance Criteria
+
+1. IF `sys` is no longer referenced after removing `sys.stdout.write()` and `sys.stdout.flush()`, THEN THE Extract_Function module SHALL remove the `sys` import statement
+2. IF `sys` is still referenced for other purposes (e.g., `sys.exit()`), THEN THE Extract_Function module SHALL retain the `sys` import statement

--- a/.kiro/specs/standardize-logging/tasks.md
+++ b/.kiro/specs/standardize-logging/tasks.md
@@ -1,0 +1,62 @@
+# Implementation Plan: Standardize Logging
+
+## Overview
+
+Replace five non-standard output calls in `Bandit/bandit.py` (bare `print()`, `sys.stdout.write()`, `sys.stdout.flush()`) with the existing Rich console (`con.print()`) and Python logger (`bandit_log`) channels. Add `from rich.rule import Rule` import and remove the unused `import sys`. All changes are in a single file with no new modules or abstractions.
+
+## Tasks
+
+- [x] 1. Update imports in `Bandit/bandit.py`
+  - [x] 1.1 Add `from rich.rule import Rule` import near the other Rich-related imports
+    - This is needed for the separator replacement in Change 4
+    - _Requirements: 2.3_
+
+  - [x] 1.2 Remove `import sys` from the imports
+    - After all `sys.stdout` calls are removed, `sys` has no remaining references
+    - _Requirements: 6.1_
+
+- [x] 2. Replace non-standard output calls in `extract()`
+  - [x] 2.1 Replace bare `print()` for invalid job directory error with dual-channel output
+    - Change `print(f'ERROR: Invalid jobs directory: {str(job_dir)}')` to `con.print(f'[red]ERROR[/]: Invalid jobs directory: {str(job_dir)}')` and add `bandit_log.error(f'Invalid jobs directory: {str(job_dir)}')`
+    - _Requirements: 1.1, 1.2, 1.3, 4.1_
+
+  - [x] 2.2 Replace `sys.stdout.write`/`sys.stdout.flush` block with `con.print('')`
+    - Replace the `if verbose: sys.stdout.write('\n')` and `sys.stdout.flush()` block (after parameter file write) with `if verbose: con.print('')`
+    - _Requirements: 3.1, 3.2, 3.3_
+
+  - [x] 2.3 Replace bare `print()` for dynamic parameter verbose message
+    - Change `print(f'Writing dynamic parameter {cparam}')` to `con.print(f'[green4]INFO[/]: Writing dynamic parameter {cparam}')`
+    - _Requirements: 2.1, 2.2_
+
+  - [x] 2.4 Replace bare `print('-'*40)` separator with Rich Rule
+    - Change `print('-'*40)` to `con.print(Rule())`
+    - _Requirements: 2.2, 2.3_
+
+- [x] 3. Checkpoint - Verify refactoring is correct
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 4. Write tests in `tests/test_standardize_logging.py`
+  - [x] 4.1 Write AST-based tests to verify prohibited patterns are absent
+    - Test that `extract` function contains no bare `print()` calls
+    - Test that `bandit.py` contains no `sys.stdout.write()` calls
+    - Test that `bandit.py` contains no `sys.stdout.flush()` calls
+    - Test that `bandit.py` does not import `sys`
+    - _Requirements: 1.3, 2.2, 3.1, 3.2, 6.1_
+
+  - [ ]* 4.2 Write example-based unit tests for the replaced call sites
+    - Test invalid job_dir triggers `con.print` with `[red]ERROR[/]` and `bandit_log.error`
+    - Test verbose dynamic parameter message uses `con.print` with `[green4]INFO[/]`
+    - Test shapefile separator uses `con.print(Rule())`
+    - Test verbose blank line uses `con.print('')`
+    - _Requirements: 1.1, 1.2, 2.1, 2.3, 3.3, 4.1, 4.3_
+
+- [x] 5. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- No property-based tests — this is a mechanical refactoring with no input-dependent logic to fuzz
+- All five changes are in `Bandit/bandit.py`; tests go in `tests/test_standardize_logging.py`

--- a/Bandit/bandit.py
+++ b/Bandit/bandit.py
@@ -3,7 +3,6 @@
 import datetime
 import logging
 import os
-import sys
 import time
 
 from packaging.version import Version
@@ -17,6 +16,8 @@ import pyogrio as pyg  # type: ignore
 from cyclopts import App, Parameter, validators
 from dask.distributed import Client
 from numpy.typing import NDArray
+
+from rich.rule import Rule
 
 from pyPRMS.base.console import get_console_instance
 
@@ -115,7 +116,8 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
             # Change into job directory before running extraction
             os.chdir(job_dir)
         else:
-            print(f'ERROR: Invalid jobs directory: {str(job_dir)}')
+            con.print(f'[red]ERROR[/]: Invalid jobs directory: {str(job_dir)}')
+            bandit_log.error(f'Invalid jobs directory: {str(job_dir)}')
             exit(-1)
 
     bandit_log.info(f'========== START {datetime.datetime.now().isoformat()} ==========')
@@ -320,8 +322,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
     ctl.get('param_file').values = str(param_filename)
 
     if verbose:
-        sys.stdout.write('\n')
-    sys.stdout.flush()
+        con.print('')
     
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Write CBH files
@@ -416,7 +417,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
                     bandit_log.warning(warn_txt)
                 else:
                     if verbose:
-                        print(f'Writing dynamic parameter {cparam}')
+                        con.print(f'[green4]INFO[/]: Writing dynamic parameter {cparam}')
 
                     mydyn = dyn_params.DynamicParameters(str(input_file), cparam, st_date, en_date, hru_order_subset)
 
@@ -494,7 +495,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
         src_gis = Path(config.gis['src_filename'])
 
         if verbose:
-            print('-'*40)
+            con.print(Rule())
             con.print('Writing shapefiles for model subset', style='green4')
 
         if len(config.gis) == 0 or not src_gis.exists():

--- a/tests/test_standardize_logging.py
+++ b/tests/test_standardize_logging.py
@@ -1,0 +1,95 @@
+"""Tests for standardized logging in bandit.py.
+
+These tests use AST inspection to verify that prohibited output patterns
+(bare print(), sys.stdout.write, sys.stdout.flush, import sys) are absent
+from the bandit.py module.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+BANDIT_PY = Path(__file__).parent.parent / 'Bandit' / 'bandit.py'
+
+
+@pytest.fixture(scope='module')
+def bandit_tree():
+    """Parse bandit.py into an AST tree."""
+    source = BANDIT_PY.read_text()
+    return ast.parse(source)
+
+
+@pytest.fixture(scope='module')
+def extract_func(bandit_tree):
+    """Get the AST node for the extract() function."""
+    for node in ast.walk(bandit_tree):
+        if isinstance(node, ast.FunctionDef) and node.name == 'extract':
+            return node
+    pytest.fail('Could not find extract() function in bandit.py')
+
+
+class TestProhibitedPatterns:
+    """AST-based tests verifying prohibited output patterns are absent."""
+
+    def test_no_bare_print_in_extract(self, extract_func):
+        """The extract function should not contain any bare print() calls.
+
+        Validates: Requirements 1.3, 2.2
+        """
+        for node in ast.walk(extract_func):
+            if isinstance(node, ast.Call):
+                func = node.func
+                # Check for bare print() call
+                if isinstance(func, ast.Name) and func.id == 'print':
+                    pytest.fail(
+                        f'Found bare print() call at line {node.lineno} in extract()'
+                    )
+
+    def test_no_sys_stdout_write(self, bandit_tree):
+        """bandit.py should not contain any sys.stdout.write() calls.
+
+        Validates: Requirement 3.1
+        """
+        for node in ast.walk(bandit_tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if (isinstance(func, ast.Attribute) and func.attr == 'write'
+                        and isinstance(func.value, ast.Attribute)
+                        and func.value.attr == 'stdout'
+                        and isinstance(func.value.value, ast.Name)
+                        and func.value.value.id == 'sys'):
+                    pytest.fail(
+                        f'Found sys.stdout.write() call at line {node.lineno}'
+                    )
+
+    def test_no_sys_stdout_flush(self, bandit_tree):
+        """bandit.py should not contain any sys.stdout.flush() calls.
+
+        Validates: Requirement 3.2
+        """
+        for node in ast.walk(bandit_tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if (isinstance(func, ast.Attribute) and func.attr == 'flush'
+                        and isinstance(func.value, ast.Attribute)
+                        and func.value.attr == 'stdout'
+                        and isinstance(func.value.value, ast.Name)
+                        and func.value.value.id == 'sys'):
+                    pytest.fail(
+                        f'Found sys.stdout.flush() call at line {node.lineno}'
+                    )
+
+    def test_no_import_sys(self, bandit_tree):
+        """bandit.py should not import the sys module.
+
+        Validates: Requirement 6.1
+        """
+        for node in ast.walk(bandit_tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == 'sys':
+                        pytest.fail(
+                            f'Found "import sys" at line {node.lineno}'
+                        )


### PR DESCRIPTION
## Summary

Replace all bare `print()` and `sys.stdout.write/flush` calls in the `extract()` function with the two established output channels: Rich console (`con.print()`) and Python logger (`bandit_log`).

## Changes

- **Invalid job directory error**: now uses dual-channel output (`con.print` with red markup + `bandit_log.error`)
- **sys.stdout.write/flush block**: replaced with `con.print('')`
- **Dynamic parameter verbose message**: uses `con.print` with `[green4]INFO[/]` markup
- **Dash separator**: replaced with Rich `Rule()`
- **Removed** unused `import sys`
- **Added** `from rich.rule import Rule` import

## Testing

4 AST-based tests in `tests/test_standardize_logging.py` verify no prohibited patterns remain:
- No bare `print()` in `extract()`
- No `sys.stdout.write()`
- No `sys.stdout.flush()`
- No `import sys`

All 25 tests pass (21 config-validator + 4 standardize-logging).