### PR TITLE
Replace bare exit() calls with BanditError exception

### DIFF
--- a/.kiro/specs/error-handling-cleanup/.config.kiro
+++ b/.kiro/specs/error-handling-cleanup/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "c8b74f36-c151-45e9-a506-1fa557c8546c", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/error-handling-cleanup/design.md
+++ b/.kiro/specs/error-handling-cleanup/design.md
@@ -1,0 +1,192 @@
+# Design Document: error-handling-cleanup
+
+## Overview
+
+This design replaces the six bare `exit()` calls in `Bandit/bandit.py`'s `extract()` function with raises of a custom `BanditError` exception, wraps the Dask `Client` in a context manager for guaranteed cleanup, and guards the `os.chdir()` call with `try/finally`. The CLI entry point (`main()`) catches `BanditError` and translates it into a `sys.exit()` call with the original exit code.
+
+The scope is intentionally narrow: only `Bandit/bandit.py` and a new `Bandit/exceptions.py` module are touched. Other scripts (`bandit_by_streamgage.py`, `bandit_helpers.py`, etc.) are out of scope for this change.
+
+### Design Decisions
+
+1. **Separate `exceptions.py` module** — `BanditError` lives in `Bandit/exceptions.py` rather than inline in `bandit.py`. This keeps the exception importable by other modules without circular dependencies and follows standard Python packaging conventions.
+
+2. **`with Client() as client:` context manager** — Dask's `Client` already supports the context manager protocol. Using `with` is the simplest way to guarantee `client.close()` on any exit path (normal, exception, or `BanditError`). The explicit `client.close()` at the end of the function is removed.
+
+3. **`try/finally` for `os.chdir()`** — A `try/finally` block wrapping the body of `extract()` restores the working directory. This is simpler than writing a custom context manager for a single use site. The guard only activates when `job_dir` is provided and valid.
+
+4. **Raise-then-catch pattern** — Each error site raises `BanditError` with the same message and exit code that the old `exit()` call used. The `main()` function catches `BanditError`, logs it, prints it, and calls `sys.exit(error.exit_code)`. This preserves all existing behavior for CLI users while making `extract()` safe to call from tests and library code.
+
+## Architecture
+
+The change is a refactor within a single module plus one new small module. No new external dependencies are introduced.
+
+```mermaid
+graph TD
+    CLI["main() — CLI entry point"] -->|calls| EXTRACT["extract()"]
+    EXTRACT -->|raises on error| BE["BanditError(exit_code, message)"]
+    CLI -->|catches BanditError| SYSEXIT["sys.exit(exit_code)"]
+    EXTRACT -->|uses| DASK["with Client() as client:"]
+    EXTRACT -->|uses| CHDIR["try/finally os.chdir()"]
+```
+
+### Control Flow
+
+1. `main()` calls `app()` which dispatches to `extract()`.
+2. Inside `extract()`, if `job_dir` is provided and valid, `os.chdir(job_dir)` runs inside a `try` block whose `finally` restores the original directory.
+3. The Dask `Client` is created with `with Client() as client:`, guaranteeing cleanup.
+4. Any error condition that previously called `exit(N)` now raises `BanditError(exit_code=N, message=...)`.
+5. `BanditError` propagates up through the `with` and `try/finally` blocks, triggering cleanup.
+6. `main()` catches `BanditError`, logs the message, prints it to the console, and calls `sys.exit(error.exit_code)`.
+
+## Components and Interfaces
+
+### 1. `Bandit/exceptions.py` (new file)
+
+```python
+class BanditError(Exception):
+    """Exception carrying an integer exit code for CLI translation."""
+
+    def __init__(self, message: str, exit_code: int = 1):
+        super().__init__(message)
+        self.exit_code = exit_code
+```
+
+- Subclass of `Exception`.
+- Stores `exit_code` as an instance attribute.
+- `str(error)` returns the message via the default `Exception.__str__`.
+- Default `exit_code` is `1` when not specified.
+
+### 2. `Bandit/bandit.py` — `extract()` changes
+
+**Imports added:**
+```python
+from Bandit.exceptions import BanditError
+```
+
+**Working directory guard** — wraps the function body after the `os.chdir()` decision:
+```python
+stdir = os.getcwd()
+chdir_needed = False
+
+if job_dir is not None:
+    job_dir = Path(job_dir) if isinstance(job_dir, str) else job_dir
+    if job_dir.is_dir():
+        os.chdir(job_dir)
+        chdir_needed = True
+    else:
+        con.print(f'[red]ERROR[/]: Invalid jobs directory: {str(job_dir)}')
+        bandit_log.error(f'Invalid jobs directory: {str(job_dir)}')
+        raise BanditError(f'Invalid jobs directory: {str(job_dir)}', exit_code=-1)
+
+try:
+    # ... entire function body ...
+finally:
+    if chdir_needed:
+        os.chdir(stdir)
+```
+
+**Dask Client context manager** — replaces the bare `Client()` + `client.close()`:
+```python
+with Client() as client:
+    dash_link = client.dashboard_link
+    con.print(f'Dask dashboard: {dash_link}')
+    # ... rest of extraction logic ...
+```
+
+**Exit-to-raise replacements** (6 sites):
+
+| Line | Old code | New code |
+|------|----------|----------|
+| ~121 | `exit(-1)` | `raise BanditError(f'Invalid jobs directory: {str(job_dir)}', exit_code=-1)` |
+| ~141 | `exit(2)` | `raise BanditError(f'Configuration has {len(errors)} error(s). Fix the above issues and retry.', exit_code=2)` |
+| ~225 | `exit(200)` | `raise BanditError('None of the requested stream segments exist in the NHM', exit_code=200)` |
+| ~275 | `exit(2)` | `raise BanditError('No HRUs associated with any of the segments', exit_code=2)` |
+| ~399 | `exit(2)` | `raise BanditError('Control file has dynamic parameters but dyn_params_dir is not specified in the config file', exit_code=2)` |
+| ~405 | `exit(2)` | `raise BanditError(f'dyn_params_dir: {config.dyn_params_dir}, does not exist.', exit_code=2)` |
+
+Each site preserves the existing `con.print()` and `bandit_log.error()` calls immediately before the raise.
+
+### 3. `Bandit/bandit.py` — `main()` changes
+
+```python
+def main():
+    try:
+        app()
+    except BanditError as err:
+        bandit_log.error(str(err))
+        con.print(f'[red]ERROR[/]: {err}')
+        sys.exit(err.exit_code)
+```
+
+**Import added:** `import sys` (at top of file).
+
+## Data Models
+
+No new data models are introduced. `BanditError` is a simple exception class with one additional attribute (`exit_code: int`). It does not persist data or interact with any storage layer.
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: BanditError construction round-trip
+
+*For any* integer `exit_code` and *any* non-empty string `message`, constructing `BanditError(message, exit_code)` SHALL produce an object where `error.exit_code == exit_code` and `str(error) == message`.
+
+**Validates: Requirements 1.2, 1.3, 1.4**
+
+### Property 2: CLI entry point translates BanditError to sys.exit
+
+*For any* `BanditError` with an arbitrary integer `exit_code` and string `message`, when `app()` raises that error, `main()` SHALL call `sys.exit()` with exactly that `exit_code` and SHALL log the message at ERROR level.
+
+**Validates: Requirements 3.1, 3.3, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6**
+
+## Error Handling
+
+The error handling strategy is the core of this feature. The key patterns:
+
+1. **Raise, don't exit** — Every error condition in `extract()` raises `BanditError` instead of calling `exit()`. The existing `con.print()` and `bandit_log.error()` calls remain in place immediately before the raise, preserving current user-visible behavior.
+
+2. **Catch at the boundary** — `main()` is the only place that catches `BanditError` and translates it to `sys.exit()`. This keeps the boundary between library code and CLI code clean.
+
+3. **Resource cleanup via language constructs** — The `with` statement for Dask `Client` and `try/finally` for `os.chdir()` guarantee cleanup regardless of how the function exits (normal return, `BanditError`, or unexpected exception).
+
+4. **No swallowing of unexpected exceptions** — `main()` only catches `BanditError`. Any other exception (e.g., `ValueError`, `IOError`) propagates normally with a full traceback, which is the correct behavior for unexpected failures.
+
+## Testing Strategy
+
+### Property-Based Tests (Hypothesis)
+
+The project already uses Hypothesis (see `tests/test_config_validator.py`). Two property-based tests will be added:
+
+- **Property 1**: Generate random `(exit_code: int, message: str)` pairs, construct `BanditError`, verify attributes. Minimum 100 iterations.
+- **Property 2**: Generate random `BanditError` instances, mock `app()` to raise them, verify `sys.exit()` is called with the correct code and the message is logged. Minimum 100 iterations.
+
+Each property test will be tagged with:
+```
+Feature: error-handling-cleanup, Property {N}: {property_text}
+```
+
+**PBT library**: Hypothesis (already a project dependency via `.hypothesis/` directory and existing tests).
+
+### Unit Tests (pytest)
+
+Example-based tests for specific scenarios:
+
+- `BanditError` is a subclass of `Exception` (Req 1.1)
+- `BanditError` defaults `exit_code` to 1 when not provided (Req 1.5)
+- `main()` does not call `sys.exit()` when no error occurs (Req 3.2)
+- No bare `exit()` calls remain in `bandit.py` (Req 2.7) — static source inspection test
+- Working directory is restored after `BanditError` is raised with a `job_dir` (Req 5.1, 5.3)
+- Working directory is unchanged when no `job_dir` is provided (Req 5.4)
+
+### Integration Tests
+
+The deeper error paths in `extract()` (Req 2.1–2.6, 4.1–4.3) require extensive mocking of the parameter database, Dask client, and filesystem. These are best covered by:
+
+- A small number of integration tests that mock the heavy dependencies and verify the correct `BanditError` is raised for each error condition.
+- Manual testing against a real NHM parameter database for end-to-end validation.
+
+### Test File
+
+All new tests go in `tests/test_error_handling.py`.

--- a/.kiro/specs/error-handling-cleanup/requirements.md
+++ b/.kiro/specs/error-handling-cleanup/requirements.md
@@ -1,0 +1,104 @@
+# Requirements Document
+
+## Introduction
+
+The `extract()` function in `Bandit/bandit.py` has three related resource-management and error-handling problems that make the code fragile, untestable, and unsuitable for use as a library:
+
+1. **Bare `exit()` calls** — The function calls `exit(-1)`, `exit(200)`, and `exit(2)` in several error paths. These terminate the Python interpreter immediately, which prevents callers from catching errors, makes the function impossible to unit-test, and blocks any use of Bandit as an imported library.
+
+2. **Unguarded Dask Client** — A `dask.distributed.Client` is created mid-function but is only closed at the very end (`client.close()`). Any early return, exception, or `exit()` call before that line leaks the client and its associated threads and network resources.
+
+3. **Unguarded `os.chdir()`** — The function changes the working directory with `os.chdir(job_dir)` near the top and only restores it with `os.chdir(stdir)` at the very end. Any error between those two points leaves the process in the wrong directory for all subsequent operations.
+
+This feature replaces the bare `exit()` calls with a custom `BanditError` exception, wraps the Dask Client in proper resource cleanup, and protects the working-directory change with a context manager or `try/finally` block. The CLI entry point (`main()`) catches `BanditError` and calls `sys.exit()` with the appropriate code.
+
+## Glossary
+
+- **Extract_Function**: The `extract()` function in `Bandit/bandit.py` that performs NHM model subset extraction.
+- **BanditError**: A custom exception class that carries an integer exit code and a human-readable message, raised in place of bare `exit()` calls.
+- **CLI_Entry_Point**: The `main()` function in `Bandit/bandit.py` that serves as the command-line entry point and delegates to `extract()` via the cyclopts `App`.
+- **Dask_Client**: An instance of `dask.distributed.Client` used for parallel computation during extraction.
+- **Working_Directory_Guard**: A mechanism (context manager or `try/finally`) that saves the current working directory before changing it and restores it when the guarded block exits, regardless of how it exits.
+
+## Requirements
+
+### Requirement 1: Define a Custom BanditError Exception
+
+**User Story:** As a developer, I want a custom exception class that carries an exit code and message, so that error conditions can be signaled without killing the interpreter.
+
+#### Acceptance Criteria
+
+1. THE BanditError SHALL be a subclass of `Exception`.
+2. THE BanditError SHALL accept an integer exit code and a string message at construction time.
+3. THE BanditError SHALL expose the exit code via an `exit_code` attribute.
+4. THE BanditError SHALL expose the message via the standard `str()` representation.
+5. WHEN no exit code is provided, THE BanditError SHALL default the exit code to 1.
+
+### Requirement 2: Replace All Bare exit() Calls with BanditError
+
+**User Story:** As a developer, I want every bare `exit()` call in the `extract()` function replaced with a `raise BanditError(...)`, so that the function can be called from tests and library code without terminating the interpreter.
+
+#### Acceptance Criteria
+
+1. WHEN an invalid job directory is provided, THE Extract_Function SHALL raise a BanditError with exit code -1 and a message that includes the invalid directory path.
+2. WHEN configuration validation fails, THE Extract_Function SHALL raise a BanditError with exit code 2 and a message that includes the number of configuration errors.
+3. WHEN none of the requested stream segments exist in the NHM, THE Extract_Function SHALL raise a BanditError with exit code 200 and a message stating that no requested segments exist.
+4. WHEN no HRUs are associated with any of the stream segments, THE Extract_Function SHALL raise a BanditError with exit code 2 and a message stating that no HRUs are associated with the segments.
+5. WHEN the control file has dynamic parameters but `dyn_params_dir` is not specified, THE Extract_Function SHALL raise a BanditError with exit code 2 and a message stating that `dyn_params_dir` is required.
+6. WHEN `dyn_params_dir` does not exist on disk, THE Extract_Function SHALL raise a BanditError with exit code 2 and a message that includes the non-existent path.
+7. THE Extract_Function SHALL contain zero calls to the built-in `exit()` function after this change.
+
+### Requirement 3: CLI Entry Point Catches BanditError and Calls sys.exit()
+
+**User Story:** As a CLI user, I want the command-line entry point to translate BanditError exceptions into proper process exit codes, so that shell scripts and CI pipelines receive the correct exit status.
+
+#### Acceptance Criteria
+
+1. WHEN the Extract_Function raises a BanditError, THE CLI_Entry_Point SHALL catch the exception, print the error message to the console, and call `sys.exit()` with the exit code from the BanditError.
+2. WHEN the Extract_Function completes without raising a BanditError, THE CLI_Entry_Point SHALL allow the process to exit normally with code 0.
+3. THE CLI_Entry_Point SHALL log the BanditError message to the bandit log at the ERROR level before exiting.
+
+### Requirement 4: Wrap the Dask Client in Resource Cleanup
+
+**User Story:** As a developer, I want the Dask Client to be properly closed regardless of how the extraction exits, so that threads, network connections, and scheduler resources are never leaked.
+
+#### Acceptance Criteria
+
+1. WHEN the Dask_Client is created, THE Extract_Function SHALL ensure the Dask_Client is closed when the guarded block exits normally.
+2. IF an exception is raised after the Dask_Client is created, THEN THE Extract_Function SHALL close the Dask_Client before the exception propagates.
+3. IF a BanditError is raised after the Dask_Client is created, THEN THE Extract_Function SHALL close the Dask_Client before the BanditError propagates.
+4. THE Extract_Function SHALL use either a context manager (`with Client() as client:`) or a `try/finally` block to guarantee Dask_Client cleanup.
+
+### Requirement 5: Guard the Working Directory Change
+
+**User Story:** As a developer, I want the working directory to be restored to its original value regardless of how the extraction exits, so that callers and subsequent operations are never left in an unexpected directory.
+
+#### Acceptance Criteria
+
+1. WHEN the Extract_Function changes the working directory via `os.chdir()`, THE Working_Directory_Guard SHALL save the original working directory before the change.
+2. WHEN the guarded block exits normally, THE Working_Directory_Guard SHALL restore the original working directory.
+3. IF an exception is raised inside the guarded block, THEN THE Working_Directory_Guard SHALL restore the original working directory before the exception propagates.
+4. IF no `job_dir` is provided, THEN THE Extract_Function SHALL not change the working directory and the Working_Directory_Guard SHALL have no effect.
+
+### Requirement 6: Preserve Existing Error Messages and Logging
+
+**User Story:** As a modeler, I want the same error messages and log entries I see today, so that my existing workflows and log-parsing scripts continue to work.
+
+#### Acceptance Criteria
+
+1. WHEN a BanditError is raised, THE Extract_Function SHALL log the same error message to the bandit log that was logged before the refactor.
+2. WHEN a BanditError is raised, THE Extract_Function SHALL print the same console message (including Rich markup) that was printed before the refactor.
+3. THE Extract_Function SHALL preserve the existing log-level (ERROR) for all error paths that previously called `exit()`.
+
+### Requirement 7: Maintain Backward-Compatible Exit Codes
+
+**User Story:** As a pipeline operator, I want the same exit codes for the same error conditions, so that my automation scripts continue to detect failures correctly.
+
+#### Acceptance Criteria
+
+1. WHEN an invalid job directory is provided, THE CLI_Entry_Point SHALL exit with code -1.
+2. WHEN configuration validation fails, THE CLI_Entry_Point SHALL exit with code 2.
+3. WHEN no requested stream segments exist in the NHM, THE CLI_Entry_Point SHALL exit with code 200.
+4. WHEN no HRUs are associated with any segments, THE CLI_Entry_Point SHALL exit with code 2.
+5. WHEN `dyn_params_dir` is required but not specified, THE CLI_Entry_Point SHALL exit with code 2.
+6. WHEN `dyn_params_dir` does not exist on disk, THE CLI_Entry_Point SHALL exit with code 2.

--- a/.kiro/specs/error-handling-cleanup/tasks.md
+++ b/.kiro/specs/error-handling-cleanup/tasks.md
@@ -1,0 +1,112 @@
+# Implementation Plan: error-handling-cleanup
+
+## Overview
+
+Replace bare `exit()` calls in `Bandit/bandit.py` with a custom `BanditError` exception, wrap the Dask `Client` in a context manager, guard `os.chdir()` with `try/finally`, and catch `BanditError` in `main()` to call `sys.exit()`. All new tests go in `tests/test_error_handling.py`.
+
+## Tasks
+
+- [x] 1. Create the BanditError exception class
+  - [x] 1.1 Create `Bandit/exceptions.py` with the `BanditError` class
+    - Subclass `Exception` with `__init__(self, message: str, exit_code: int = 1)`
+    - Store `exit_code` as an instance attribute
+    - Default `exit_code` to `1` when not provided
+    - `str(error)` returns the message via standard `Exception.__str__`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+  - [x] 1.2 Write property test for BanditError construction round-trip
+    - **Property 1: BanditError construction round-trip**
+    - For any integer `exit_code` and any non-empty string `message`, constructing `BanditError(message, exit_code)` produces an object where `error.exit_code == exit_code` and `str(error) == message`
+    - Use Hypothesis to generate random `(exit_code: int, message: str)` pairs, minimum 100 examples
+    - **Validates: Requirements 1.2, 1.3, 1.4**
+
+  - [x] 1.3 Write unit tests for BanditError
+    - Test that `BanditError` is a subclass of `Exception`
+    - Test that default `exit_code` is `1` when not provided
+    - Test that `str(error)` returns the message
+    - _Requirements: 1.1, 1.4, 1.5_
+
+- [x] 2. Replace bare exit() calls with BanditError raises in extract()
+  - [x] 2.1 Add `from Bandit.exceptions import BanditError` import to `bandit.py`
+    - Add the import alongside existing Bandit imports
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_
+
+  - [x] 2.2 Replace the invalid job directory `exit(-1)` with `raise BanditError`
+    - Replace `exit(-1)` with `raise BanditError(f'Invalid jobs directory: {str(job_dir)}', exit_code=-1)`
+    - Preserve existing `con.print()` and `bandit_log.error()` calls before the raise
+    - _Requirements: 2.1, 6.1, 6.2, 6.3, 7.1_
+
+  - [x] 2.3 Replace the configuration validation `exit(2)` with `raise BanditError`
+    - Replace `exit(2)` with `raise BanditError(f'Configuration has {len(errors)} error(s). Fix the above issues and retry.', exit_code=2)`
+    - Preserve existing error logging and console output
+    - _Requirements: 2.2, 6.1, 6.2, 6.3, 7.2_
+
+  - [x] 2.4 Replace the missing stream segments `exit(200)` with `raise BanditError`
+    - Replace `exit(200)` with `raise BanditError('None of the requested stream segments exist in the NHM', exit_code=200)`
+    - Preserve existing `con.print()` and `bandit_log.error()` calls
+    - _Requirements: 2.3, 6.1, 6.2, 6.3, 7.3_
+
+  - [x] 2.5 Replace the no-HRUs `exit(2)` with `raise BanditError`
+    - Replace `exit(2)` with `raise BanditError('No HRUs associated with any of the segments', exit_code=2)`
+    - Preserve existing error logging and console output
+    - _Requirements: 2.4, 6.1, 6.2, 6.3, 7.4_
+
+  - [x] 2.6 Replace the two dynamic parameters `exit(2)` calls with `raise BanditError`
+    - Replace `exit(2)` for missing `dyn_params_dir` config with `raise BanditError('Control file has dynamic parameters but dyn_params_dir is not specified in the config file', exit_code=2)`
+    - Replace `exit(2)` for non-existent `dyn_params_dir` path with `raise BanditError(f'dyn_params_dir: {config.dyn_params_dir}, does not exist.', exit_code=2)`
+    - Add `con.print()` calls before each raise to match the pattern of other error sites
+    - _Requirements: 2.5, 2.6, 6.1, 6.2, 6.3, 7.5, 7.6_
+
+  - [x] 2.7 Write a static inspection unit test verifying no bare exit() calls remain
+    - Read `Bandit/bandit.py` source and assert zero calls to `exit()` (excluding `sys.exit`)
+    - _Requirements: 2.7_
+
+- [x] 3. Wrap Dask Client in context manager and guard os.chdir() with try/finally
+  - [x] 3.1 Wrap the Dask `Client()` call with `with Client() as client:`
+    - Replace `client = Client()` with `with Client() as client:` and indent the block that uses `client`
+    - Remove the explicit `client.close()` call at the end of `extract()`
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [x] 3.2 Add `try/finally` guard for `os.chdir()` restoration
+    - Save `stdir = os.getcwd()` and track `chdir_needed` flag
+    - Wrap the function body after the chdir decision in `try/finally`
+    - In the `finally` block, restore `os.chdir(stdir)` only if `chdir_needed` is `True`
+    - Remove the explicit `os.chdir(stdir)` at the end of `extract()`
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+- [x] 4. Checkpoint
+  - Ensure all changes compile and the existing test suite passes. Ask the user if questions arise.
+
+- [x] 5. Update main() to catch BanditError and call sys.exit()
+  - [x] 5.1 Add `import sys` to `bandit.py` imports
+    - Add `import sys` at the top of the file with the other standard library imports
+    - _Requirements: 3.1_
+
+  - [x] 5.2 Wrap `app()` call in `main()` with try/except for BanditError
+    - Catch `BanditError`, log the message at ERROR level via `bandit_log.error()`, print to console via `con.print()`, and call `sys.exit(err.exit_code)`
+    - Allow normal completion (no BanditError) to exit with code 0
+    - _Requirements: 3.1, 3.2, 3.3_
+
+  - [x] 5.3 Write property test for CLI entry point BanditError translation
+    - **Property 2: CLI entry point translates BanditError to sys.exit**
+    - For any `BanditError` with an arbitrary integer `exit_code` and string `message`, when `app()` raises that error, `main()` calls `sys.exit()` with exactly that `exit_code`
+    - Mock `app()` to raise generated `BanditError` instances, verify `sys.exit()` receives the correct exit code
+    - Use Hypothesis, minimum 100 examples
+    - **Validates: Requirements 3.1, 3.3, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6**
+
+  - [x] 5.4 Write unit tests for main() behavior
+    - Test that `main()` does not call `sys.exit()` when no error occurs (mock `app()` to succeed)
+    - Test that `main()` logs the error message at ERROR level before exiting
+    - _Requirements: 3.1, 3.2, 3.3_
+
+- [x] 6. Final checkpoint
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- All new tests go in `tests/test_error_handling.py` using pytest and Hypothesis (already project dependencies)

--- a/Bandit/bandit.py
+++ b/Bandit/bandit.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import os
+import sys
 import time
 
 from packaging.version import Version
@@ -22,6 +23,7 @@ from rich.rule import Rule
 from pyPRMS.base.console import get_console_instance
 
 from Bandit import __version__
+from Bandit.exceptions import BanditError
 from Bandit.bandit_helpers import (create_parameter_subset, parse_gages, set_date, subset_stream_network,
                                    get_hru_and_seg_subset_maps, get_output_order, get_poi_subset)
 from Bandit.git_version import git_commit, git_repo, git_branch, git_commit_url
@@ -107,6 +109,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
         prms_version: Version = Version(prms_version)
 
     stdir = os.getcwd()
+    chdir_needed = False
 
     if job_dir is not None:
         if isinstance(job_dir, str):
@@ -115,471 +118,481 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
         if job_dir.is_dir():
             # Change into job directory before running extraction
             os.chdir(job_dir)
+            chdir_needed = True
         else:
             con.print(f'[red]ERROR[/]: Invalid jobs directory: {str(job_dir)}')
             bandit_log.error(f'Invalid jobs directory: {str(job_dir)}')
-            exit(-1)
+            raise BanditError(f'Invalid jobs directory: {str(job_dir)}', exit_code=-1)
 
-    bandit_log.info(f'========== START {datetime.datetime.now().isoformat()} ==========')
+    try:
+        bandit_log.info(f'========== START {datetime.datetime.now().isoformat()} ==========')
 
-    addl_gages = None
-    if add_gages:
-        addl_gages = parse_gages(add_gages)
-        if verbose:
-            con.print(f'Additional streamgages: {addl_gages}')
-        bandit_log.info('Additionals streamgages specified on command line')
+        addl_gages = None
+        if add_gages:
+            addl_gages = parse_gages(add_gages)
+            if verbose:
+                con.print(f'Additional streamgages: {addl_gages}')
+            bandit_log.info('Additionals streamgages specified on command line')
 
-    config = bc.Cfg(config_file)
+        config = bc.Cfg(config_file)
 
-    validator = ConfigValidator(config)
-    errors = validator.validate()
-    if errors:
-        for err in errors:
-            bandit_log.error(err)
-            con.print(f'[red]ERROR[/]: {err}')
-        con.print(f'[red]Configuration has {len(errors)} error(s). Fix the above issues and retry.[/]')
-        exit(2)
+        validator = ConfigValidator(config)
+        errors = validator.validate()
+        if errors:
+            for err in errors:
+                bandit_log.error(err)
+                con.print(f'[red]ERROR[/]: {err}')
+            con.print(f'[red]Configuration has {len(errors)} error(s). Fix the above issues and retry.[/]')
+            raise BanditError(f'Configuration has {len(errors)} error(s). Fix the above issues and retry.', exit_code=2)
 
-    outdir = Path(config.output_dir)   # Where to output the subset
-    param_filename = Path(config.param_filename)   # Name of the output parameter file
-    paramdb_dir = Path(config.paramdb_dir)   # Location of the NHM parameter database
-    cbh_dir = Path(config.cbh_dir)
-    dsmost_seg = config.outlets   # List of outlets
-    uscutoff_seg = config.cutoffs   # List of upstream cutoffs
-    hru_noroute = np.array(config.hru_noroute)   # Array of additional HRUs (have no route to segment within subset)
+        outdir = Path(config.output_dir)   # Where to output the subset
+        param_filename = Path(config.param_filename)   # Name of the output parameter file
+        paramdb_dir = Path(config.paramdb_dir)   # Location of the NHM parameter database
+        cbh_dir = Path(config.cbh_dir)
+        dsmost_seg = config.outlets   # List of outlets
+        uscutoff_seg = config.cutoffs   # List of upstream cutoffs
+        hru_noroute = np.array(config.hru_noroute)   # Array of additional HRUs (have no route to segment within subset)
 
-    # if prms_version == 6:
-    #     cbh_netcdf = True
-    #     param_netcdf = True
-    #     streamflow_netcdf = True
+        # if prms_version == 6:
+        #     cbh_netcdf = True
+        #     param_netcdf = True
+        #     streamflow_netcdf = True
 
-    # Load PRMS metadata
-    con.print(f'[green4]INFO[/]: Loading PRMS metadata for version {prms_version}')
-    prms_meta = MetaData(version=prms_version, verbose=verbose).metadata
+        # Load PRMS metadata
+        con.print(f'[green4]INFO[/]: Loading PRMS metadata for version {prms_version}')
+        prms_meta = MetaData(version=prms_version, verbose=verbose).metadata
 
-    # Load the control file
-    ctl = ControlFile(config.control_filename, metadata=prms_meta, verbose=verbose, include_missing=True)
+        # Load the control file
+        ctl = ControlFile(config.control_filename, metadata=prms_meta, verbose=verbose, include_missing=True)
 
-    # Date range for pulling NWIS streamgage observations and CBH data
-    st_date = set_date(config.start_date)
-    en_date = set_date(config.end_date)
+        # Date range for pulling NWIS streamgage observations and CBH data
+        st_date = set_date(config.start_date)
+        en_date = set_date(config.end_date)
 
-    # Adjust the start and end dates in the control file to reflect
-    # date range from bandit config file
-    ctl.get('start_time').values = st_date
-    ctl.get('end_time').values = en_date
+        # Adjust the start and end dates in the control file to reflect
+        # date range from bandit config file
+        ctl.get('start_time').values = st_date
+        ctl.get('end_time').values = en_date
 
-    # Output revision of NhmParamDb
-    git_url = git_commit_url(paramdb_dir)
-    nhmparamdb_revision = git_commit(paramdb_dir, length=7)
-    bandit_log.info(f'Parameter database: {git_repo(paramdb_dir)}')
-    bandit_log.info(f'Branch: {git_branch(paramdb_dir)}')
-    bandit_log.info(f'Commit: {nhmparamdb_revision}')
+        # Output revision of NhmParamDb
+        git_url = git_commit_url(paramdb_dir)
+        nhmparamdb_revision = git_commit(paramdb_dir, length=7)
+        bandit_log.info(f'Parameter database: {git_repo(paramdb_dir)}')
+        bandit_log.info(f'Branch: {git_branch(paramdb_dir)}')
+        bandit_log.info(f'Commit: {nhmparamdb_revision}')
 
-    # client = Client(threads_per_worker=1)
-    client = Client()
-    dash_link = client.dashboard_link
-    con.print(f'Dask dashboard: {dash_link}')
+        # client = Client(threads_per_worker=1)
+        with Client() as client:
+            dash_link = client.dashboard_link
+            con.print(f'Dask dashboard: {dash_link}')
 
-    # Load the NHMparamdb
-    if verbose:
-        con.print(f'[green4]INFO[/]: Parameter database: {git_repo(paramdb_dir)}')
-        con.print(f'[green4]INFO[/]: Branch: {git_branch(paramdb_dir)}')
-        con.print(f'[green4]INFO[/]: Commit: {nhmparamdb_revision}')
+            # Load the NHMparamdb
+            if verbose:
+                con.print(f'[green4]INFO[/]: Parameter database: {git_repo(paramdb_dir)}')
+                con.print(f'[green4]INFO[/]: Branch: {git_branch(paramdb_dir)}')
+                con.print(f'[green4]INFO[/]: Commit: {nhmparamdb_revision}')
 
-    pdb = ParamDb(paramdb_dir=paramdb_dir, metadata=prms_meta, verbose=verbose)
-    pdb.control = ctl
+            pdb = ParamDb(paramdb_dir=paramdb_dir, metadata=prms_meta, verbose=verbose)
+            pdb.control = ctl
 
-    if pdb.dimensions.exists('npoigages') and not pdb.dimensions.exists('nobs'):
-        # If we have poi gages and nobs is missing then add it
-        if verbose:
-            con.print('[gold3]WARNING[/]: Added missing nobs dimension')
-        pdb.dimensions.add('nobs', size=pdb.dimensions.get('npoigages').size)
-
-    # Add defaults for parameters that are missing but required for the selected modules
-    # WARNING: 20240726 PAN - if hru_segment_nhm is missing from the paramdb no warning is issued,
-    #                         and the wrong number of HRUs will likely be output for the extraction.
-    pdb.add_missing_parameters()
-
-    if not no_filter_params:
-        # Reduce the parameters to those required by the selected modules
-        pdb.remove(pdb.unneeded_parameters)
-
-    if not pdb.exists('poi_gage_segment'):
-        con.print('[gold3]WARNING[/]: Missing POI-related parameters. To include POIs, set csvON_OFF > 0 in the control file')
-
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Get tosegment_nhm
-    # Convert to list for fastest access to array
-    nhm_seg = pdb.get('nhm_seg').data
-
-    # First check if any of the requested stream segments exist in the NHM.
-    # An intersection of 0 elements can occur when all stream segments are
-    # not included in the NHM (e.g. segments in Alaska).
-    # NOTE: It's possible to have a stream segment that does not exist in
-    #       tosegment but does exist in nhm_seg (e.g. standalone segment). So
-    #       we use nhm_seg to verify at least one of the given segment(s) exist.
-    if dsmost_seg and len(set(dsmost_seg).intersection(set(nhm_seg))) == 0:
-        con.print(f'[red]ERROR[/]: None of the requested stream segments exist in the NHM')
-        bandit_log.error('None of the requested stream segments exist in the NHM paramDb')
-        exit(200)
-
-    # Build the stream network
-    dag_ds = pdb.stream_network(tosegment='tosegment_nhm', seg_id='nhm_seg')
-
-    bandit_log.debug(f'Number of NHM downstream nodes: {dag_ds.number_of_nodes()}')
-    bandit_log.debug(f'Number of NHM downstream edges: {dag_ds.number_of_edges()}')
-
-    if config.check_DAG:
-        if not nx.is_directed_acyclic_graph(dag_ds):
-            con.print('[red]ERROR[/]: Cycles and/or loops found in stream network')
-            bandit_log.error('Cycles and/or loops found in stream network')
-
-            for xx in nx.simple_cycles(dag_ds):
-                con.print(f'[red]ERROR[/]: Cycle found for segment {xx}')
-                bandit_log.error(f'Cycle found for segment {xx}')
-
-    dag_ds_subset = subset_stream_network(dag_ds, uscutoff_seg, dsmost_seg)
-
-    # Segments in model subset
-    new_nhm_seg = np.array([ee[0] for ee in dag_ds_subset.edges])
-    con.print(f'[green4]INFO[/]: Number of stream segments in model subset: {len(new_nhm_seg)}')
-    bandit_log.info(f'Number of segments in model subset: {len(new_nhm_seg)}')
-    if verbose:
-        con.print(f'segments: {new_nhm_seg}')
-
-    # Using a dictionary mapping nhm_seg to 1-based index for speed
-    new_nhm_seg_to_idx1 = dict((ss, ii+1) for ii, ss in enumerate(new_nhm_seg))
-
-    # Generate the renumbered local tosegments (1-based with zero being an outlet)
-    new_tosegment = [new_nhm_seg_to_idx1[ee[1]] if ee[1] in new_nhm_seg_to_idx1
-                     else 0 for ee in dag_ds_subset.edges]
-
-    # 2019-09-16 PAN: This initially assumed hru_segment in the monolithic paramdb was ALWAYS
-    #                 ordered 1..nhru. This is not always the case so the nhm_id parameter
-    #                 needs to be loaded and used to map the nhm HRU ids to their
-    #                 respective indices.
-    hru_segment = pdb.get('hru_segment_nhm').data
-    nhm_id = pdb.get('nhm_id').data
-    nhm_id_to_idx = pdb.get('nhm_id').index_map
-    bandit_log.info(f'Number of NHM hru_segment entries: {hru_segment.size}')
-
-    # Create a dictionaries mapping hru_segment segments to hru_segment 1-based indices filtered by
-    # new_nhm_seg and hru_noroute.
-    seg_to_hru, hru_to_seg = get_hru_and_seg_subset_maps(hru_segment, nhm_id, new_nhm_seg, hru_noroute)
-
-    if set(hru_to_seg.values()) == set(hru_noroute):
-        # This occurs when there are no ROUTED HRUs for any of the stream segments
-        con.print('[red]ERROR[/]: No HRUs associated with any of the segments')
-        bandit_log.error('No HRUs associated with any of the segments; exiting.')
-        exit(2)
-
-    # HRU-related parameters can either be output with the legacy, segment-oriented order
-    # or can be output maintaining their original HRU-relative order from the parameter database.
-    hru_order_subset, new_hru_segment = get_output_order(hru_to_seg, seg_to_hru, hru_segment,
-                                                         nhm_id_to_idx, new_nhm_seg_to_idx1, hru_noroute,
-                                                         keep_hru_order=keep_hru_order)
-
-    con.print(f'[green4]INFO[/]: Number of HRUs in model subset: {len(hru_order_subset)}')
-    bandit_log.info(f'Number of HRUs in subset: {len(hru_order_subset)}')
-    bandit_log.info(f'Size of hru_segment for subset: {len(new_hru_segment)}')
-    if verbose:
-        con.print(f'HRUs: {hru_order_subset}')
-
-    # Use hru_order_subset to pull selected indices for parameters with nhru dimensions
-    # hru_order_subset contains the in-order indices for the subset of hru_segments
-    # new_hru_segment contains the in-order indices for the subset of tosegments
-    # --------------------------------------------------------------------------
-
-    # @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Subset poi_gage_segment
-    new_poi_gage_segment, new_poi_gage_id, new_poi_type = get_poi_subset(pdb, new_nhm_seg_to_idx1,
-                                                                         seg_to_hru,
-                                                                         addl_gages=addl_gages)
-
-    con.print(f'[green4]INFO[/]: Number of POI gages in model subset: {len(new_poi_gage_id)}')
-
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Process the parameters and create a parameter file for the subset
-    new_ps = create_parameter_subset(prms_meta, pdb, hru_order_subset,
-                                     new_hru_segment, new_nhm_seg, new_poi_gage_id,
-                                     new_poi_gage_segment, new_poi_type, new_tosegment)
-
-    # Write the new parameter file
-    if verbose:
-        con.print(f'[green4]INFO[/]: Writing parameter file for PRMS {prms_version}')
-
-    header = [f'Written by Bandit version {__version__} for PRMS {prms_version}',
-              f'ParamDb revision: {git_url}']
-    if param_netcdf:
-        # TODO: 2023-11-13 PAN - add version info and prms version as global attributes
-        param_filename = Path(f'{param_filename.stem}.nc')
-        new_ps.write_parameter_netcdf(outdir / param_filename)
-    else:
-        new_ps.write_parameter_file(outdir / param_filename, header=header)
-
-    ctl.get('param_file').values = str(param_filename)
-
-    if verbose:
-        con.print('')
-    
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Write CBH files
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if config.output_cbh:
-        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        # Subset the cbh files for the selected HRUs
-        if verbose:
-            con.print('Processing CBH files', style='green4')
-
-        # Read the CBH source file
-        if cbh_dir.suffix == '.nc':
-            cbh_hdl = Cbh(cbh_dir, metadata=prms_meta, engine='netcdf')
-        elif cbh_dir.suffix == '.zarr':
-            cbh_hdl = Cbh(cbh_dir, metadata=prms_meta, engine='zarr')
-        else:
-            raise ValueError('Missing CBH files')
-
-        # Add the global NHM IDs from source parameter database
-        cbh_hdl.set_nhm_id(pdb.get('nhm_id').data)
-
-        if cbh_netcdf:
-            cbh_outfile = outdir / 'cbh.nc'
-
-            global_attrs = dict(bandit_version=__version__, paramdb_url=git_url)
-            cbh_hdl.write_netcdf(cbh_outfile, variables=list(config.cbh_var_map.keys()),
-                                 global_attrs=global_attrs, time_slice=slice(st_date, en_date),
-                                 hru_ids=hru_order_subset)
-
-            # Set the control file variables for the CBH files
-            for cfv in config.cbh_var_map.values():
-                ctl.get(cfv).values = cbh_outfile.name
-        else:
-            for cvar, cfv in config.cbh_var_map.items():
+            if pdb.dimensions.exists('npoigages') and not pdb.dimensions.exists('nobs'):
+                # If we have poi gages and nobs is missing then add it
                 if verbose:
-                    con.print(f'--- {cvar}')
+                    con.print('[gold3]WARNING[/]: Added missing nobs dimension')
+                pdb.dimensions.add('nobs', size=pdb.dimensions.get('npoigages').size)
 
-                cfile = ctl.get(cfv).values
-                cbh_hdl.write_ascii(cfile, variable=cvar, time_slice=slice(st_date, en_date), hru_ids=hru_order_subset)
+            # Add defaults for parameters that are missing but required for the selected modules
+            # WARNING: 20240726 PAN - if hru_segment_nhm is missing from the paramdb no warning is issued,
+            #                         and the wrong number of HRUs will likely be output for the extraction.
+            pdb.add_missing_parameters()
 
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Write output variables
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if config.include_model_output:
-        src_model_output = Path(config.output_vars_dir)
-        model_output_dir = outdir / 'model_output'
-        model_output_dir.mkdir(exist_ok=True)
+            if not no_filter_params:
+                # Reduce the parameters to those required by the selected modules
+                pdb.remove(pdb.unneeded_parameters)
 
-        model_output_ds = ModelOutput(filename=src_model_output)
+            if not pdb.exists('poi_gage_segment'):
+                con.print('[gold3]WARNING[/]: Missing POI-related parameters. To include POIs, set csvON_OFF > 0 in the control file')
 
-        for cvar in config.output_vars:
-            if model_output_netcdf:
-                model_output_ds.write_netcdf(filename=model_output_dir / f'{cvar}.nc',
-                                             variables=cvar,
-                                             time_slice=slice(st_date, en_date),
-                                             hru_ids=hru_order_subset,
-                                             seg_ids=new_nhm_seg)
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Get tosegment_nhm
+            # Convert to list for fastest access to array
+            nhm_seg = pdb.get('nhm_seg').data
+
+            # First check if any of the requested stream segments exist in the NHM.
+            # An intersection of 0 elements can occur when all stream segments are
+            # not included in the NHM (e.g. segments in Alaska).
+            # NOTE: It's possible to have a stream segment that does not exist in
+            #       tosegment but does exist in nhm_seg (e.g. standalone segment). So
+            #       we use nhm_seg to verify at least one of the given segment(s) exist.
+            if dsmost_seg and len(set(dsmost_seg).intersection(set(nhm_seg))) == 0:
+                con.print(f'[red]ERROR[/]: None of the requested stream segments exist in the NHM')
+                bandit_log.error('None of the requested stream segments exist in the NHM paramDb')
+                raise BanditError('None of the requested stream segments exist in the NHM', exit_code=200)
+
+            # Build the stream network
+            dag_ds = pdb.stream_network(tosegment='tosegment_nhm', seg_id='nhm_seg')
+
+            bandit_log.debug(f'Number of NHM downstream nodes: {dag_ds.number_of_nodes()}')
+            bandit_log.debug(f'Number of NHM downstream edges: {dag_ds.number_of_edges()}')
+
+            if config.check_DAG:
+                if not nx.is_directed_acyclic_graph(dag_ds):
+                    con.print('[red]ERROR[/]: Cycles and/or loops found in stream network')
+                    bandit_log.error('Cycles and/or loops found in stream network')
+
+                    for xx in nx.simple_cycles(dag_ds):
+                        con.print(f'[red]ERROR[/]: Cycle found for segment {xx}')
+                        bandit_log.error(f'Cycle found for segment {xx}')
+
+            dag_ds_subset = subset_stream_network(dag_ds, uscutoff_seg, dsmost_seg)
+
+            # Segments in model subset
+            new_nhm_seg = np.array([ee[0] for ee in dag_ds_subset.edges])
+            con.print(f'[green4]INFO[/]: Number of stream segments in model subset: {len(new_nhm_seg)}')
+            bandit_log.info(f'Number of segments in model subset: {len(new_nhm_seg)}')
+            if verbose:
+                con.print(f'segments: {new_nhm_seg}')
+
+            # Using a dictionary mapping nhm_seg to 1-based index for speed
+            new_nhm_seg_to_idx1 = dict((ss, ii+1) for ii, ss in enumerate(new_nhm_seg))
+
+            # Generate the renumbered local tosegments (1-based with zero being an outlet)
+            new_tosegment = [new_nhm_seg_to_idx1[ee[1]] if ee[1] in new_nhm_seg_to_idx1
+                             else 0 for ee in dag_ds_subset.edges]
+
+            # 2019-09-16 PAN: This initially assumed hru_segment in the monolithic paramdb was ALWAYS
+            #                 ordered 1..nhru. This is not always the case so the nhm_id parameter
+            #                 needs to be loaded and used to map the nhm HRU ids to their
+            #                 respective indices.
+            hru_segment = pdb.get('hru_segment_nhm').data
+            nhm_id = pdb.get('nhm_id').data
+            nhm_id_to_idx = pdb.get('nhm_id').index_map
+            bandit_log.info(f'Number of NHM hru_segment entries: {hru_segment.size}')
+
+            # Create a dictionaries mapping hru_segment segments to hru_segment 1-based indices filtered by
+            # new_nhm_seg and hru_noroute.
+            seg_to_hru, hru_to_seg = get_hru_and_seg_subset_maps(hru_segment, nhm_id, new_nhm_seg, hru_noroute)
+
+            if set(hru_to_seg.values()) == set(hru_noroute):
+                # This occurs when there are no ROUTED HRUs for any of the stream segments
+                con.print('[red]ERROR[/]: No HRUs associated with any of the segments')
+                bandit_log.error('No HRUs associated with any of the segments; exiting.')
+                raise BanditError('No HRUs associated with any of the segments', exit_code=2)
+
+            # HRU-related parameters can either be output with the legacy, segment-oriented order
+            # or can be output maintaining their original HRU-relative order from the parameter database.
+            hru_order_subset, new_hru_segment = get_output_order(hru_to_seg, seg_to_hru, hru_segment,
+                                                                 nhm_id_to_idx, new_nhm_seg_to_idx1, hru_noroute,
+                                                                 keep_hru_order=keep_hru_order)
+
+            con.print(f'[green4]INFO[/]: Number of HRUs in model subset: {len(hru_order_subset)}')
+            bandit_log.info(f'Number of HRUs in subset: {len(hru_order_subset)}')
+            bandit_log.info(f'Size of hru_segment for subset: {len(new_hru_segment)}')
+            if verbose:
+                con.print(f'HRUs: {hru_order_subset}')
+
+            # Use hru_order_subset to pull selected indices for parameters with nhru dimensions
+            # hru_order_subset contains the in-order indices for the subset of hru_segments
+            # new_hru_segment contains the in-order indices for the subset of tosegments
+            # --------------------------------------------------------------------------
+
+            # @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Subset poi_gage_segment
+            new_poi_gage_segment, new_poi_gage_id, new_poi_type = get_poi_subset(pdb, new_nhm_seg_to_idx1,
+                                                                                 seg_to_hru,
+                                                                                 addl_gages=addl_gages)
+
+            con.print(f'[green4]INFO[/]: Number of POI gages in model subset: {len(new_poi_gage_id)}')
+
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Process the parameters and create a parameter file for the subset
+            new_ps = create_parameter_subset(prms_meta, pdb, hru_order_subset,
+                                             new_hru_segment, new_nhm_seg, new_poi_gage_id,
+                                             new_poi_gage_segment, new_poi_type, new_tosegment)
+
+            # Write the new parameter file
+            if verbose:
+                con.print(f'[green4]INFO[/]: Writing parameter file for PRMS {prms_version}')
+
+            header = [f'Written by Bandit version {__version__} for PRMS {prms_version}',
+                      f'ParamDb revision: {git_url}']
+            if param_netcdf:
+                # TODO: 2023-11-13 PAN - add version info and prms version as global attributes
+                param_filename = Path(f'{param_filename.stem}.nc')
+                new_ps.write_parameter_netcdf(outdir / param_filename)
             else:
-                model_output_ds.write_csv(pathname=model_output_dir,
-                                          variables=cvar,
-                                          time_slice=slice(st_date, en_date),
-                                          hru_ids=hru_order_subset,
-                                          seg_ids=new_nhm_seg)
+                new_ps.write_parameter_file(outdir / param_filename, header=header)
 
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Write dynamic parameters
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if ctl.has_dynamic_parameters:
-        if config.dyn_params_dir is None:
-            bandit_log.error('Control file has dynamic parameters but dyn_params_dir is not specified ' +
-                             'in the config file')
-            exit(2)
-        else:
-            dyn_params_dir = Path(config.dyn_params_dir)
+            ctl.get('param_file').values = str(param_filename)
 
-            if not dyn_params_dir.is_dir():
-                bandit_log.error(f'dyn_params_dir: {config.dyn_params_dir}, does not exist.')
-                exit(2)
+            if verbose:
+                con.print('')
+    
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Write CBH files
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            if config.output_cbh:
+                # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                # Subset the cbh files for the selected HRUs
+                if verbose:
+                    con.print('Processing CBH files', style='green4')
 
-            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            # Add dynamic parameters
-            for cparam in ctl.dynamic_parameters:
-                param_name = f'dyn_{cparam}'
-                input_file = dyn_params_dir / f'{param_name}.nc'
-                output_file = outdir / f'{param_name}.param'
-
-                if not input_file.is_file():
-                    warn_txt = f'WARNING: CONUS dynamic parameter file: {input_file}, does not exist... skipping'
-                    bandit_log.warning(warn_txt)
+                # Read the CBH source file
+                if cbh_dir.suffix == '.nc':
+                    cbh_hdl = Cbh(cbh_dir, metadata=prms_meta, engine='netcdf')
+                elif cbh_dir.suffix == '.zarr':
+                    cbh_hdl = Cbh(cbh_dir, metadata=prms_meta, engine='zarr')
                 else:
-                    if verbose:
-                        con.print(f'[green4]INFO[/]: Writing dynamic parameter {cparam}')
+                    raise ValueError('Missing CBH files')
 
-                    mydyn = dyn_params.DynamicParameters(str(input_file), cparam, st_date, en_date, hru_order_subset)
+                # Add the global NHM IDs from source parameter database
+                cbh_hdl.set_nhm_id(pdb.get('nhm_id').data)
 
-                    mydyn.read_netcdf()
-                    out_order = [kk for kk in hru_order_subset]
+                if cbh_netcdf:
+                    cbh_outfile = outdir / 'cbh.nc'
 
-                    out_order = ['year', 'month', 'day'] + out_order
-                    # for cc in ['day', 'month', 'year']:
-                    #     out_order.insert(0, cc)
+                    global_attrs = dict(bandit_version=__version__, paramdb_url=git_url)
+                    cbh_hdl.write_netcdf(cbh_outfile, variables=list(config.cbh_var_map.keys()),
+                                         global_attrs=global_attrs, time_slice=slice(st_date, en_date),
+                                         hru_ids=hru_order_subset)
 
-                    header = ' '.join(map(str, out_order))   # type: ignore
+                    # Set the control file variables for the CBH files
+                    for cfv in config.cbh_var_map.values():
+                        ctl.get(cfv).values = cbh_outfile.name
+                else:
+                    for cvar, cfv in config.cbh_var_map.items():
+                        if verbose:
+                            con.print(f'--- {cvar}')
 
-                    # Output ASCII files
-                    with open(output_file, 'w') as out_ascii:
-                        out_ascii.write(f'{cparam}\n')
-                        out_ascii.write(f'{header}\n')
-                        out_ascii.write('####\n')
-                        mydyn.data.to_csv(out_ascii, columns=out_order, na_rep='-999',
-                                          sep=' ', index=False, header=False, encoding=None, chunksize=50)
+                        cfile = ctl.get(cfv).values
+                        cbh_hdl.write_ascii(cfile, variable=cvar, time_slice=slice(st_date, en_date), hru_ids=hru_order_subset)
 
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Write control file
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Default the various *ON_OFF variables to 0 (off)
-    # The original values are needed to reduce parameters by module,
-    # but it's best to disable them in the final control file since
-    # no output variables are defined for them.
-    disable_vars = ['basinOutON_OFF', 'csvON_OFF', 'mapOutON_OFF', 'nhruOutON_OFF',
-                    'nsegmentOutON_OFF', 'nsubOutON_OFF']
-    for vv in disable_vars:
-        ctl.get(vv).values = 0
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Write output variables
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            if config.include_model_output:
+                src_model_output = Path(config.output_vars_dir)
+                model_output_dir = outdir / 'model_output'
+                model_output_dir.mkdir(exist_ok=True)
 
-    ctl.write(str(Path(config.control_filename).with_suffix('.bandit')))
+                model_output_ds = ModelOutput(filename=src_model_output)
 
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # Write streamflow
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    if config.output_streamflow:
-        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        # Download the streamgage information from NWIS
-        if len(new_poi_gage_id) > 0:
-            if verbose:
-                con.print(f'[green4]INFO[/]: Retrieving streamgage observations for {len(new_poi_gage_id)} stations', style='green4')
-
-            if config.exists('poi_dir') and config.poi_dir != '':
-                bandit_log.info('Retrieving POIs from local HYDAT and NWIS netcdf files')
-                streamflow = POI(src_path=config.poi_dir, st_date=st_date, en_date=en_date,
-                                 gage_ids=new_poi_gage_id, verbose=verbose)
-            else:
-                # Default to retrieving only NWIS stations from waterservices.usgs.gov
-                bandit_log.info('No poi_dir: retrieving only NWIS POIs from online NWIS service.')
-                streamflow = prms_nwis.NWIS(gage_ids=new_poi_gage_id, st_date=st_date, en_date=en_date,
-                                            verbose=verbose)
-                streamflow.get_daily_streamgage_observations()
-
-            if streamflow_netcdf:
-                streamflow.write_netcdf(filename=outdir / f'{config.streamflow_filename}.nc')
-            else:
-                streamflow.write_ascii(filename=outdir / f'{config.streamflow_filename}')
-        else:
-            # TODO: 2025-03-25 PAN - this should write a netcdf file if that option was selected
-            if verbose:
-                con.print('[green4]WARNING[/]: No POIs exist in model subset; writing dummy data', style='gold3')
-            streamflow = prms_nwis.NWIS(gage_ids=None, st_date=st_date, en_date=en_date, verbose=verbose)
-            streamflow.get_daily_streamgage_observations()
-            streamflow.write_ascii(filename=outdir / f'{config.streamflow_filename}')
-            bandit_log.info(f'No POIs exist in model subset; dummy data written.')
-
-    # *******************************************
-    # Create a shapefile of the selected HRUs
-    if config.output_shapefiles:
-        stime = time.time()
-
-        src_gis = Path(config.gis['src_filename'])
-
-        if verbose:
-            con.print(Rule())
-            con.print('Writing shapefiles for model subset', style='green4')
-
-        if len(config.gis) == 0 or not src_gis.exists():
-            bandit_log.error(f'Source GIS file'
-                             f'does not exist. Shapefiles will not be created')
-        else:
-            # Create GIS subdirectory if it doesn't already exist
-            gis_dir = outdir / 'GIS'
-            gis_dir.mkdir(exist_ok=True)
-
-            dst_gis_type = config.gis["dst_extension"]
-            geo_outfile = gis_dir / f'model_layers.{dst_gis_type}'
-
-            for kk, vv in config.gis['layers'].items():
-                vv['include_fields'].extend([vv['key']])
-
-                if vv['type'] == 'nhru':
-                    geo_file = pyg.read_dataframe(src_gis, layer=vv['layer'],
-                                                  columns=vv['include_fields'], force_2d=True,
-                                                  where=f'{vv["key"]} >= {min(hru_order_subset)} AND {vv["key"]} <= {max(hru_order_subset)}')
-                    bb = geo_file[geo_file[vv['key']].isin(hru_order_subset)]
-                    bb = bb.rename(columns={vv['key']: 'nhm_id'})
-                    local_ids = new_ps.get_dataframe('nhm_id').reset_index()
-                    bb = bb.merge(local_ids, on='nhm_id')
-
-                    # Buffer the HRUs to make them visible to reduce/remove artifacts
-                    # in the dissolved layer caused by tiny gaps between HRUs
-                    bb2 = bb.copy()
-                    # bb2['geometry'] = bb2['geometry'].buffer(0.0002)
-                    domain_layer = bb2.dissolve(aggfunc={'nhm_id': 'count'})
-                    domain_layer.rename(columns={'nhm_id': 'num_hrus'}, inplace=True)
-
-                    if dst_gis_type == 'gpkg':
-                        bb.to_file(geo_outfile, layer=vv['type'], driver='GPKG')
-                        domain_layer.to_file(geo_outfile, layer='domain', driver='GPKG')
+                for cvar in config.output_vars:
+                    if model_output_netcdf:
+                        model_output_ds.write_netcdf(filename=model_output_dir / f'{cvar}.nc',
+                                                     variables=cvar,
+                                                     time_slice=slice(st_date, en_date),
+                                                     hru_ids=hru_order_subset,
+                                                     seg_ids=new_nhm_seg)
                     else:
-                        geo_outfile = gis_dir / f'model_{vv["type"]}.{dst_gis_type}'
-                        bb.to_file(geo_outfile)
+                        model_output_ds.write_csv(pathname=model_output_dir,
+                                                  variables=cvar,
+                                                  time_slice=slice(st_date, en_date),
+                                                  hru_ids=hru_order_subset,
+                                                  seg_ids=new_nhm_seg)
 
-                        domain_outfile = gis_dir / f'model_domain.{dst_gis_type}'
-                        domain_layer.to_file(domain_outfile)
-                elif vv['type'] == 'nsegment':
-                    geo_file = pyg.read_dataframe(src_gis, layer=vv['layer'],
-                                                  columns=vv['include_fields'], force_2d=True,
-                                                  where=f'{vv["key"]} >= {min(new_nhm_seg)} AND {vv["key"]} <= {max(new_nhm_seg)}')
-                    bb = geo_file[geo_file[vv['key']].isin(new_nhm_seg)]
-                    bb = bb.rename(columns={vv['key']: 'nhm_seg'})
-                    local_ids = new_ps.get_dataframe('nhm_seg').reset_index()
-                    bb = bb.merge(local_ids, on='nhm_seg')
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Write dynamic parameters
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            if ctl.has_dynamic_parameters:
+                if config.dyn_params_dir is None:
+                    con.print('[red]ERROR[/]: Control file has dynamic parameters but dyn_params_dir is not specified in the config file')
+                    bandit_log.error('Control file has dynamic parameters but dyn_params_dir is not specified ' +
+                                     'in the config file')
+                    raise BanditError('Control file has dynamic parameters but dyn_params_dir is not specified in the config file', exit_code=2)
+                else:
+                    dyn_params_dir = Path(config.dyn_params_dir)
 
-                    if dst_gis_type == 'gpkg':
-                        bb.to_file(geo_outfile, layer=vv['type'], driver='GPKG')
-                    else:
-                        geo_outfile = gis_dir / f'model_{vv["type"]}.{dst_gis_type}'
-                        bb.to_file(geo_outfile)
-                elif vv['type'] == 'npoigages':
-                    if len(new_poi_gage_id) > 0:
-                        geo_file = pyg.read_dataframe(src_gis, layer=vv['layer'],
-                                                      columns=vv['include_fields'], force_2d=True)
+                    if not dyn_params_dir.is_dir():
+                        con.print(f'[red]ERROR[/]: dyn_params_dir: {config.dyn_params_dir}, does not exist.')
+                        bandit_log.error(f'dyn_params_dir: {config.dyn_params_dir}, does not exist.')
+                        raise BanditError(f'dyn_params_dir: {config.dyn_params_dir}, does not exist.', exit_code=2)
 
-                        bb = geo_file[geo_file[vv['key']].isin(new_poi_gage_id)]
-                        bb = bb.rename(columns={vv['key']: 'gage_id', vv['include_fields'][0]: 'nhm_seg'})
+                    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    # Add dynamic parameters
+                    for cparam in ctl.dynamic_parameters:
+                        param_name = f'dyn_{cparam}'
+                        input_file = dyn_params_dir / f'{param_name}.nc'
+                        output_file = outdir / f'{param_name}.param'
 
-                        if dst_gis_type == 'gpkg':
-                            bb.to_file(geo_outfile, layer=vv['type'], driver='GPKG')
+                        if not input_file.is_file():
+                            warn_txt = f'WARNING: CONUS dynamic parameter file: {input_file}, does not exist... skipping'
+                            bandit_log.warning(warn_txt)
                         else:
-                            geo_outfile = gis_dir / f'model_{vv["type"]}.{dst_gis_type}'
-                            bb.to_file(geo_outfile)
+                            if verbose:
+                                con.print(f'[green4]INFO[/]: Writing dynamic parameter {cparam}')
+
+                            mydyn = dyn_params.DynamicParameters(str(input_file), cparam, st_date, en_date, hru_order_subset)
+
+                            mydyn.read_netcdf()
+                            out_order = [kk for kk in hru_order_subset]
+
+                            out_order = ['year', 'month', 'day'] + out_order
+                            # for cc in ['day', 'month', 'year']:
+                            #     out_order.insert(0, cc)
+
+                            header = ' '.join(map(str, out_order))   # type: ignore
+
+                            # Output ASCII files
+                            with open(output_file, 'w') as out_ascii:
+                                out_ascii.write(f'{cparam}\n')
+                                out_ascii.write(f'{header}\n')
+                                out_ascii.write('####\n')
+                                mydyn.data.to_csv(out_ascii, columns=out_order, na_rep='-999',
+                                                  sep=' ', index=False, header=False, encoding=None, chunksize=50)
+
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Write control file
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Default the various *ON_OFF variables to 0 (off)
+            # The original values are needed to reduce parameters by module,
+            # but it's best to disable them in the final control file since
+            # no output variables are defined for them.
+            disable_vars = ['basinOutON_OFF', 'csvON_OFF', 'mapOutON_OFF', 'nhruOutON_OFF',
+                            'nsegmentOutON_OFF', 'nsubOutON_OFF']
+            for vv in disable_vars:
+                ctl.get(vv).values = 0
+
+            ctl.write(str(Path(config.control_filename).with_suffix('.bandit')))
+
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            # Write streamflow
+            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            if config.output_streamflow:
+                # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                # Download the streamgage information from NWIS
+                if len(new_poi_gage_id) > 0:
+                    if verbose:
+                        con.print(f'[green4]INFO[/]: Retrieving streamgage observations for {len(new_poi_gage_id)} stations', style='green4')
+
+                    if config.exists('poi_dir') and config.poi_dir != '':
+                        bandit_log.info('Retrieving POIs from local HYDAT and NWIS netcdf files')
+                        streamflow = POI(src_path=config.poi_dir, st_date=st_date, en_date=en_date,
+                                         gage_ids=new_poi_gage_id, verbose=verbose)
                     else:
-                        bandit_log.info('No POIs in model subset so POI GIS layer not written.')
+                        # Default to retrieving only NWIS stations from waterservices.usgs.gov
+                        bandit_log.info('No poi_dir: retrieving only NWIS POIs from online NWIS service.')
+                        streamflow = prms_nwis.NWIS(gage_ids=new_poi_gage_id, st_date=st_date, en_date=en_date,
+                                                    verbose=verbose)
+                        streamflow.get_daily_streamgage_observations()
+
+                    if streamflow_netcdf:
+                        streamflow.write_netcdf(filename=outdir / f'{config.streamflow_filename}.nc')
+                    else:
+                        streamflow.write_ascii(filename=outdir / f'{config.streamflow_filename}')
                 else:
-                    bandit_log.warning(f'Layer, {kk}, has unknown type, {vv["type"]}; skipping.')
+                    # TODO: 2025-03-25 PAN - this should write a netcdf file if that option was selected
+                    if verbose:
+                        con.print('[green4]WARNING[/]: No POIs exist in model subset; writing dummy data', style='gold3')
+                    streamflow = prms_nwis.NWIS(gage_ids=None, st_date=st_date, en_date=en_date, verbose=verbose)
+                    streamflow.get_daily_streamgage_observations()
+                    streamflow.write_ascii(filename=outdir / f'{config.streamflow_filename}')
+                    bandit_log.info(f'No POIs exist in model subset; dummy data written.')
 
-        if verbose:
-            con.print(f'[green4]INFO[/]: Geo write time: {time.time() - stime:0.3f} s')
+            # *******************************************
+            # Create a shapefile of the selected HRUs
+            if config.output_shapefiles:
+                stime = time.time()
 
-    bandit_log.info(f'========== END {datetime.datetime.now().isoformat()} ==========')
+                src_gis = Path(config.gis['src_filename'])
 
-    client.close()
-    os.chdir(stdir)
+                if verbose:
+                    con.print(Rule())
+                    con.print('Writing shapefiles for model subset', style='green4')
+
+                if len(config.gis) == 0 or not src_gis.exists():
+                    bandit_log.error(f'Source GIS file'
+                                     f'does not exist. Shapefiles will not be created')
+                else:
+                    # Create GIS subdirectory if it doesn't already exist
+                    gis_dir = outdir / 'GIS'
+                    gis_dir.mkdir(exist_ok=True)
+
+                    dst_gis_type = config.gis["dst_extension"]
+                    geo_outfile = gis_dir / f'model_layers.{dst_gis_type}'
+
+                    for kk, vv in config.gis['layers'].items():
+                        vv['include_fields'].extend([vv['key']])
+
+                        if vv['type'] == 'nhru':
+                            geo_file = pyg.read_dataframe(src_gis, layer=vv['layer'],
+                                                          columns=vv['include_fields'], force_2d=True,
+                                                          where=f'{vv["key"]} >= {min(hru_order_subset)} AND {vv["key"]} <= {max(hru_order_subset)}')
+                            bb = geo_file[geo_file[vv['key']].isin(hru_order_subset)]
+                            bb = bb.rename(columns={vv['key']: 'nhm_id'})
+                            local_ids = new_ps.get_dataframe('nhm_id').reset_index()
+                            bb = bb.merge(local_ids, on='nhm_id')
+
+                            # Buffer the HRUs to make them visible to reduce/remove artifacts
+                            # in the dissolved layer caused by tiny gaps between HRUs
+                            bb2 = bb.copy()
+                            # bb2['geometry'] = bb2['geometry'].buffer(0.0002)
+                            domain_layer = bb2.dissolve(aggfunc={'nhm_id': 'count'})
+                            domain_layer.rename(columns={'nhm_id': 'num_hrus'}, inplace=True)
+
+                            if dst_gis_type == 'gpkg':
+                                bb.to_file(geo_outfile, layer=vv['type'], driver='GPKG')
+                                domain_layer.to_file(geo_outfile, layer='domain', driver='GPKG')
+                            else:
+                                geo_outfile = gis_dir / f'model_{vv["type"]}.{dst_gis_type}'
+                                bb.to_file(geo_outfile)
+
+                                domain_outfile = gis_dir / f'model_domain.{dst_gis_type}'
+                                domain_layer.to_file(domain_outfile)
+                        elif vv['type'] == 'nsegment':
+                            geo_file = pyg.read_dataframe(src_gis, layer=vv['layer'],
+                                                          columns=vv['include_fields'], force_2d=True,
+                                                          where=f'{vv["key"]} >= {min(new_nhm_seg)} AND {vv["key"]} <= {max(new_nhm_seg)}')
+                            bb = geo_file[geo_file[vv['key']].isin(new_nhm_seg)]
+                            bb = bb.rename(columns={vv['key']: 'nhm_seg'})
+                            local_ids = new_ps.get_dataframe('nhm_seg').reset_index()
+                            bb = bb.merge(local_ids, on='nhm_seg')
+
+                            if dst_gis_type == 'gpkg':
+                                bb.to_file(geo_outfile, layer=vv['type'], driver='GPKG')
+                            else:
+                                geo_outfile = gis_dir / f'model_{vv["type"]}.{dst_gis_type}'
+                                bb.to_file(geo_outfile)
+                        elif vv['type'] == 'npoigages':
+                            if len(new_poi_gage_id) > 0:
+                                geo_file = pyg.read_dataframe(src_gis, layer=vv['layer'],
+                                                              columns=vv['include_fields'], force_2d=True)
+
+                                bb = geo_file[geo_file[vv['key']].isin(new_poi_gage_id)]
+                                bb = bb.rename(columns={vv['key']: 'gage_id', vv['include_fields'][0]: 'nhm_seg'})
+
+                                if dst_gis_type == 'gpkg':
+                                    bb.to_file(geo_outfile, layer=vv['type'], driver='GPKG')
+                                else:
+                                    geo_outfile = gis_dir / f'model_{vv["type"]}.{dst_gis_type}'
+                                    bb.to_file(geo_outfile)
+                            else:
+                                bandit_log.info('No POIs in model subset so POI GIS layer not written.')
+                        else:
+                            bandit_log.warning(f'Layer, {kk}, has unknown type, {vv["type"]}; skipping.')
+
+                if verbose:
+                    con.print(f'[green4]INFO[/]: Geo write time: {time.time() - stime:0.3f} s')
+
+            bandit_log.info(f'========== END {datetime.datetime.now().isoformat()} ==========')
+
+    finally:
+        if chdir_needed:
+            os.chdir(stdir)
 
 
 def main():
-    app()
+    try:
+        app()
+    except BanditError as err:
+        bandit_log.error(str(err))
+        con.print(f'[red]ERROR[/]: {err}')
+        sys.exit(err.exit_code)
 
 
 if __name__ == '__main__':

--- a/Bandit/exceptions.py
+++ b/Bandit/exceptions.py
@@ -1,0 +1,6 @@
+class BanditError(Exception):
+    """Exception carrying an integer exit code for CLI translation."""
+
+    def __init__(self, message: str, exit_code: int = 1):
+        super().__init__(message)
+        self.exit_code = exit_code

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,190 @@
+"""Tests for error handling: BanditError exception and CLI integration."""
+
+import ast
+from pathlib import Path
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from Bandit.exceptions import BanditError
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests (Hypothesis)
+# ---------------------------------------------------------------------------
+
+
+# Feature: error-handling-cleanup, Property 1: BanditError construction round-trip
+class TestPropertyBanditErrorConstructionRoundTrip:
+    """Property 1: For any integer exit_code and any non-empty string message,
+    constructing BanditError(message, exit_code) produces an object where
+    error.exit_code == exit_code and str(error) == message.
+
+    **Validates: Requirements 1.2, 1.3, 1.4**
+    """
+
+    @given(
+        exit_code=st.integers(),
+        message=st.text(min_size=1),
+    )
+    @settings(max_examples=100)
+    def test_construction_round_trip(self, exit_code, message):
+        """BanditError preserves exit_code and message through construction."""
+        error = BanditError(message, exit_code)
+        assert error.exit_code == exit_code, (
+            f"Expected exit_code={exit_code}, got {error.exit_code}"
+        )
+        assert str(error) == message, (
+            f"Expected str(error)={message!r}, got {str(error)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — BanditError basics
+# ---------------------------------------------------------------------------
+
+
+class TestBanditErrorUnit:
+    """Unit tests for BanditError construction and behavior.
+
+    Validates: Requirements 1.1, 1.4, 1.5
+    """
+
+    def test_is_subclass_of_exception(self):
+        """BanditError should be a subclass of Exception."""
+        assert issubclass(BanditError, Exception)
+
+    def test_default_exit_code_is_one(self):
+        """When no exit_code is provided, it should default to 1."""
+        error = BanditError("something went wrong")
+        assert error.exit_code == 1
+
+    def test_str_returns_message(self):
+        """str(error) should return the message passed at construction."""
+        error = BanditError("file not found", exit_code=2)
+        assert str(error) == "file not found"
+
+
+# ---------------------------------------------------------------------------
+# Static inspection — no bare exit() calls
+# ---------------------------------------------------------------------------
+
+
+class TestNoBareExitCalls:
+    """Static inspection test verifying no bare exit() calls remain in bandit.py.
+
+    Validates: Requirement 2.7
+    """
+
+    @staticmethod
+    def _find_bare_exit_calls(source: str) -> list[int]:
+        """Parse *source* with AST and return line numbers of bare ``exit()`` calls.
+
+        A "bare exit()" is a call whose function node is a plain ``Name``
+        with ``id == 'exit'``.  Calls to ``sys.exit`` (represented as an
+        ``Attribute`` node with ``attr == 'exit'``) are intentionally
+        excluded.
+        """
+        tree = ast.parse(source)
+        bare_exit_lines: list[int] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                # Bare exit(): the function is just a Name node with id "exit"
+                if isinstance(func, ast.Name) and func.id == "exit":
+                    bare_exit_lines.append(node.lineno)
+        return bare_exit_lines
+
+    def test_no_bare_exit_calls_in_bandit_py(self):
+        """Bandit/bandit.py must contain zero bare exit() calls."""
+        bandit_py = Path(__file__).resolve().parent.parent / "Bandit" / "bandit.py"
+        source = bandit_py.read_text(encoding="utf-8")
+
+        bare_exit_lines = self._find_bare_exit_calls(source)
+
+        assert bare_exit_lines == [], (
+            f"Found bare exit() call(s) on line(s) {bare_exit_lines} in Bandit/bandit.py. "
+            f"Replace them with 'raise BanditError(...)' per the design."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests — CLI entry point
+# ---------------------------------------------------------------------------
+
+
+# Feature: error-handling-cleanup, Property 2: CLI entry point translates BanditError to sys.exit
+class TestPropertyCLIEntryPointBanditErrorTranslation:
+    """Property 2: For any BanditError with an arbitrary integer exit_code
+    and string message, when app() raises that error, main() calls sys.exit()
+    with exactly that exit_code.
+
+    **Validates: Requirements 3.1, 3.3, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6**
+    """
+
+    @given(
+        exit_code=st.integers(),
+        message=st.text(min_size=1),
+    )
+    @settings(max_examples=100, deadline=None)
+    def test_main_translates_bandit_error_to_sys_exit(self, exit_code, message):
+        """main() catches BanditError from app() and calls sys.exit(exit_code)."""
+        import pytest
+        from unittest.mock import patch
+
+        from Bandit.bandit import main
+
+        error = BanditError(message, exit_code)
+
+        with patch("Bandit.bandit.app", side_effect=error):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+            assert exc_info.value.code == exit_code, (
+                f"Expected sys.exit({exit_code}), got sys.exit({exc_info.value.code})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — main() behavior
+# ---------------------------------------------------------------------------
+
+
+class TestMainBehavior:
+    """Unit tests for main() success and error-logging paths.
+
+    Validates: Requirements 3.1, 3.2, 3.3
+    """
+
+    def test_main_no_sys_exit_on_success(self):
+        """When app() succeeds, main() should return normally without SystemExit.
+
+        **Validates: Requirement 3.2**
+        """
+        from unittest.mock import patch
+
+        from Bandit.bandit import main
+
+        with patch("Bandit.bandit.app"):
+            # If main() calls sys.exit(), pytest will see a SystemExit exception.
+            # A successful run should complete without raising anything.
+            main()
+
+    def test_main_logs_error_before_exit(self):
+        """When app() raises BanditError, main() logs the message at ERROR level.
+
+        **Validates: Requirements 3.1, 3.3**
+        """
+        import pytest
+        from unittest.mock import patch
+
+        from Bandit.bandit import main
+
+        error = BanditError("test msg", exit_code=42)
+
+        with patch("Bandit.bandit.app", side_effect=error), \
+             patch("Bandit.bandit.bandit_log") as mock_log:
+            with pytest.raises(SystemExit):
+                main()
+
+            mock_log.error.assert_called_once_with("test msg")

--- a/tests/test_standardize_logging.py
+++ b/tests/test_standardize_logging.py
@@ -81,15 +81,4 @@ class TestProhibitedPatterns:
                         f'Found sys.stdout.flush() call at line {node.lineno}'
                     )
 
-    def test_no_import_sys(self, bandit_tree):
-        """bandit.py should not import the sys module.
 
-        Validates: Requirement 6.1
-        """
-        for node in ast.walk(bandit_tree):
-            if isinstance(node, ast.Import):
-                for alias in node.names:
-                    if alias.name == 'sys':
-                        pytest.fail(
-                            f'Found "import sys" at line {node.lineno}'
-                        )


### PR DESCRIPTION
## Summary

Replaces the six bare `exit()` calls in `Bandit/bandit.py` with a custom `BanditError` exception, adds proper resource cleanup, and updates the CLI entry point to translate exceptions into exit codes.

## Changes

- **`Bandit/exceptions.py`** (new) — `BanditError(message, exit_code)` exception class
- **`Bandit/bandit.py`** — Replace all bare `exit()` calls with `raise BanditError(...)`, wrap Dask `Client` in `with` context manager, guard `os.chdir()` with `try/finally`, update `main()` to catch `BanditError` and call `sys.exit()`
- **`tests/test_error_handling.py`** (new) — 8 tests including 2 property-based tests (Hypothesis) and unit tests
- **`tests/test_standardize_logging.py`** — Removed obsolete `test_no_import_sys` (sys is now required)

## What was tested

- All 8 new tests pass (property-based + unit + static inspection)
- Existing test suite continues to pass
- File compiles cleanly (AST parse verified)

## Motivation

The bare `exit()` calls made `extract()` impossible to unit-test or use as a library. The Dask Client and `os.chdir()` lacked cleanup guarantees on error paths. This refactor makes the function safe to call from tests and library code while preserving all existing CLI behavior and exit codes.