### PR TITLE
Replace subset_stream_network with pyPRMS get_streamnet_subset

### DIFF
--- a/Bandit/bandit.py
+++ b/Bandit/bandit.py
@@ -2,44 +2,41 @@
 
 import datetime
 import logging
-import os
-import sys
-import time
-
-from packaging.version import Version
-from pathlib import Path
-from typing import Annotated, List, Optional, Union
-
 import networkx as nx   # type: ignore
 import numpy as np
+import os
 import pyogrio as pyg  # type: ignore
+import sys
+import time
 
 from cyclopts import App, Parameter, validators
 from dask.distributed import Client
 from numpy.typing import NDArray
-
+from packaging.version import Version
+from pathlib import Path
 from rich.rule import Rule
+from typing import Annotated, List, Optional, Union
 
 from pyPRMS.base.console import get_console_instance
+from pyPRMS import Cbh   # type: ignore
+from pyPRMS import ControlFile   # type: ignore
+from pyPRMS import ParamDb   # type: ignore
+from pyPRMS import Parameters   # type: ignore
+from pyPRMS.constants import HRU_DIMS, PRMS_VERSION   # type: ignore
+from pyPRMS.metadata.metadata import MetaData   # type: ignore
+from pyPRMS.prms_helpers import get_streamnet_subset   # type: ignore
 
 from Bandit import __version__
-from Bandit.exceptions import BanditError
-from Bandit.bandit_helpers import (create_parameter_subset, parse_gages, set_date, subset_stream_network,
+from Bandit.bandit_helpers import (create_parameter_subset, parse_gages, set_date,
                                    get_hru_and_seg_subset_maps, get_output_order, get_poi_subset)
-from Bandit.git_version import git_commit, git_repo, git_branch, git_commit_url
 from Bandit.config_validator import ConfigValidator
+from Bandit.exceptions import BanditError
+from Bandit.git_version import git_commit, git_repo, git_branch, git_commit_url
 from Bandit.model_output import ModelOutput
 from Bandit.points_of_interest import POI   # type: ignore
 import Bandit.bandit_cfg as bc   # type: ignore
 import Bandit.dynamic_parameters as dyn_params
 import Bandit.prms_nwis as prms_nwis   # type: ignore
-
-from pyPRMS.constants import HRU_DIMS, PRMS_VERSION   # type: ignore
-from pyPRMS.metadata.metadata import MetaData   # type: ignore
-from pyPRMS import Cbh   # type: ignore
-from pyPRMS import ControlFile   # type: ignore
-from pyPRMS import ParamDb   # type: ignore
-from pyPRMS import Parameters   # type: ignore
 
 import warnings
 warnings.filterwarnings('ignore', message=r'.*Measured \(M\) geometry types are not supported.*')
@@ -244,7 +241,7 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
                         con.print(f'[red]ERROR[/]: Cycle found for segment {xx}')
                         bandit_log.error(f'Cycle found for segment {xx}')
 
-            dag_ds_subset = subset_stream_network(dag_ds, uscutoff_seg, dsmost_seg)
+            dag_ds_subset = get_streamnet_subset(dag_ds, uscutoff_seg, dsmost_seg)
 
             # Segments in model subset
             new_nhm_seg = np.array([ee[0] for ee in dag_ds_subset.edges])
@@ -580,7 +577,6 @@ def extract(config_file: Annotated[Path, Parameter(validator=validators.Path(exi
                     con.print(f'[green4]INFO[/]: Geo write time: {time.time() - stime:0.3f} s')
 
             bandit_log.info(f'========== END {datetime.datetime.now().isoformat()} ==========')
-
     finally:
         if chdir_needed:
             os.chdir(stdir)

--- a/Bandit/bandit_helpers.py
+++ b/Bandit/bandit_helpers.py
@@ -1,12 +1,11 @@
 
 import datetime
 import logging
-import networkx as nx   # type: ignore
 import numpy as np
 import re
 
 from numpy.typing import NDArray
-from typing import Union, Dict, List, Optional, Set, Tuple
+from typing import Union, Dict, List, Optional, Tuple
 
 from pyPRMS.base.console import get_console_instance
 from pyPRMS.constants import MetaDataType
@@ -73,85 +72,7 @@ def set_date(adate: Union[datetime.datetime, datetime.date, str]) -> datetime.da
         return datetime.datetime(*[int(x) for x in re.split('[- :]', adate)])  # type: ignore
 
 
-def subset_stream_network(dag_ds: nx.classes.digraph.DiGraph,
-                          uscutoff_seg: List[int],
-                          dsmost_seg: List[int]) -> nx.classes.digraph.DiGraph:
-    """Extract subset of stream network
 
-    :param dag_ds: Directed, acyclic graph of downstream stream network
-    :param uscutoff_seg: List of upstream cutoff segments
-    :param dsmost_seg: List of outlet segments to start extraction from
-
-    :returns: Stream network of extracted segments
-    """
-    # Create the upstream graph
-    # TODO: 2021-12-01 PAN - the reverse function is pretty inefficient for multi-location
-    #       jobs.
-    dag_us = dag_ds.reverse()
-    logger.debug('Number of NHM upstream nodes: {}'.format(dag_us.number_of_nodes()))
-    logger.debug('Number of NHM upstream edges: {}'.format(dag_us.number_of_edges()))
-
-    # Trim the u/s graph to remove segments above the u/s cutoff segments
-    try:
-        for xx in uscutoff_seg:
-            try:
-                dag_us.remove_nodes_from(nx.dfs_predecessors(dag_us, xx))
-
-                # Also remove the cutoff segment itself
-                dag_us.remove_node(xx)
-            except KeyError:
-                print('WARNING: nhm_segment {} does not exist in stream network'.format(xx))
-    except TypeError:
-        logger.error('\nSelected cutoffs should at least be an empty list instead of NoneType.')
-        exit(200)
-
-    logger.debug('Number of NHM upstream nodes (trimmed): {}'.format(dag_us.number_of_nodes()))
-    logger.debug('Number of NHM upstream edges (trimmed): {}'.format(dag_us.number_of_edges()))
-
-    # =======================================
-    # Given a d/s segment (dsmost_seg) create a subset of u/s segments
-
-    # Get all unique segments u/s of the starting segment
-    uniq_seg_us: Set[int] = set()
-    if dsmost_seg:
-        for xx in dsmost_seg:
-            try:
-                pred = nx.dfs_predecessors(dag_us, xx)
-                uniq_seg_us = uniq_seg_us.union(set(pred.keys()).union(set(pred.values())))
-            except KeyError:
-                logger.error('KeyError: Segment {} does not exist in stream network'.format(xx))
-                # print('\nKeyError: Segment {} does not exist in stream network'.format(xx))
-
-        # Get a subgraph in the dag_ds graph and return the edges
-        dag_ds_subset = dag_ds.subgraph(uniq_seg_us).copy()
-
-        # 2018-02-13 PAN: It is possible to have outlets specified which are not truly
-        #                 outlets in the most conservative sense (e.g. a point where
-        #                 the stream network exits the study area). This occurs when
-        #                 doing headwater extractions where all segments for a headwater
-        #                 are specified in the configuration file. Instead of creating
-        #                 output edges for all specified 'outlets' the set difference
-        #                 between the specified outlets and nodes in the graph subset
-        #                 which have no edges is performed first to reduce the number of
-        #                 outlets to the 'true' outlets of the system.
-        node_outlets = [ee[0] for ee in dag_ds_subset.edges()]
-        true_outlets = set(dsmost_seg).difference(set(node_outlets))
-        logger.debug('node_outlets: {}'.format(','.join(map(str, node_outlets))))
-        logger.debug('true_outlets: {}'.format(','.join(map(str, true_outlets))))
-
-        # Add the downstream segments that exit the subgraph
-        for xx in true_outlets:
-            nhm_outlet = list(dag_ds.neighbors(xx))[0]
-            dag_ds_subset.add_node(nhm_outlet, style='filled', fontcolor='white', fillcolor='grey')
-            dag_ds_subset.add_edge(xx, nhm_outlet)
-            dag_ds_subset.nodes[xx]['style'] = 'filled'
-            dag_ds_subset.nodes[xx]['fontcolor'] = 'white'
-            dag_ds_subset.nodes[xx]['fillcolor'] = 'blue'
-    else:
-        # No outlets specified so pull the CONUS
-        dag_ds_subset = dag_ds
-
-    return dag_ds_subset
 
 
 def create_parameter_subset(prms_meta: MetaDataType,


### PR DESCRIPTION
## Replace duplicate subset_stream_network with pyPRMS get_streamnet_subset

**Base:** `development`
**Branch:** `refactor/use-pyprms-streamnet-subset`

### Summary

`subset_stream_network` in `bandit_helpers.py` was a duplicate of `get_streamnet_subset` in `pyPRMS.prms_helpers`. The two implementations are identical in algorithm — both reverse the DAG, trim upstream cutoff segments, gather predecessor nodes for each outlet, build the subgraph, and add exit nodes for true outlets. The only differences were cosmetic (logging style, type hint syntax, error handling approach).

This PR removes the Bandit copy and imports the pyPRMS version directly.

### Changes

- **`Bandit/bandit_helpers.py`**
  - Removed `subset_stream_network` function (~80 lines)
  - Removed unused `import networkx as nx`
  - Removed unused `Set` from typing imports

- **`Bandit/bandit.py`**
  - Added `from pyPRMS.prms_helpers import get_streamnet_subset`
  - Removed `subset_stream_network` from `bandit_helpers` import
  - Updated call site to use `get_streamnet_subset`

### Notes

- The pyPRMS version uses Rich console output for warnings/errors instead of bare `print()` and `logger.error()` + `exit(200)`, which aligns better with the project's conventions.
- The function signature and return type are identical, so no downstream changes are needed.
- The commented-out `build_extraction` block still references the old name but is dead code.